### PR TITLE
feat: OQM-0005 add dimmed loading overlay with spinner during API operations (…

### DIFF
--- a/user_stories/application/features/OQM-0005-spinner-during-api-operations/prompt.md
+++ b/user_stories/application/features/OQM-0005-spinner-during-api-operations/prompt.md
@@ -1,4 +1,4 @@
-Implement the feature described in GitHub issue #x:
+Implement the feature described in GitHub issue #10:
 - Apply all relevant instructions from [copilot-instructions.md](http://_vscodecontentref_/0) and [frontend-instructions](http://_vscodecontentref_/1)
 - Use TDD and update documentation as required
 - Create a dedicated branch named after the issue (e.g., feature/issue-123-description). Implement the feature in this branch. Open a PR to merge into main/master only after review and CI checks pass.

--- a/web/src/features/coach/components/CoachLoginDialog.tsx
+++ b/web/src/features/coach/components/CoachLoginDialog.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
 import { RegisterPinDialog } from '../../../shared/components/RegisterPinDialog/RegisterPinDialog';
 import type { RegisterPinData } from '../../../shared/components/RegisterPinDialog/RegisterPinDialog';
+import { LoadingOverlay } from '../../../shared/components/LoadingOverlay/LoadingOverlay';
 import { registerCoachPin, verifyCoachPin } from '../api/coach.api';
 import type { CoachLoginDialogProps } from '../types';
 import styles from './CoachLoginDialog.module.css';
@@ -33,6 +34,7 @@ export function CoachLoginDialog({ open, coachPassword, onLoginSuccess, onCancel
   const [passwordError, setPasswordError] = useState('');
   const [pinError, setPinError] = useState('');
   const [registerPinOpen, setRegisterPinOpen] = useState(false);
+  const [isVerifying, setIsVerifying] = useState(false);
 
   if (!open) return null;
 
@@ -40,7 +42,8 @@ export function CoachLoginDialog({ open, coachPassword, onLoginSuccess, onCancel
   const loginEnabled = password.length > 0;
 
   async function handleVerify() {
-    if (!pinValid) return;
+    if (!pinValid || isVerifying) return;
+    setIsVerifying(true);
     try {
       const coachData = await verifyCoachPin(pin);
       toast.success(t('coachLogin.loginSuccess'));
@@ -49,6 +52,8 @@ export function CoachLoginDialog({ open, coachPassword, onLoginSuccess, onCancel
       setPinError(t('coachLogin.invalidPin'));
       setPin('');
       setPassword('');
+    } finally {
+      setIsVerifying(false);
     }
   }
 
@@ -101,7 +106,7 @@ export function CoachLoginDialog({ open, coachPassword, onLoginSuccess, onCancel
                 maxLength={6}
                 aria-label={t('coachLogin.enterPin')}
               />
-              <button onClick={handleVerify} disabled={!pinValid}>
+              <button onClick={handleVerify} disabled={!pinValid || isVerifying}>
                 {t('coachLogin.verify')}
               </button>
             </div>
@@ -157,6 +162,8 @@ export function CoachLoginDialog({ open, coachPassword, onLoginSuccess, onCancel
         onCancel={handleRegisterPinCancel}
         showAlias={true}
       />
+
+      <LoadingOverlay visible={isVerifying} />
     </>
   );
 }

--- a/web/src/features/coach/components/__tests__/CoachLoginDialog.test.tsx
+++ b/web/src/features/coach/components/__tests__/CoachLoginDialog.test.tsx
@@ -237,4 +237,46 @@ describe('CoachLoginDialog', () => {
     );
     expect(screen.getByLabelText('Enter PIN code')).toHaveValue('9876');
   });
+
+  // ── Loading overlay (OQM-0005) ────────────────────────────────────────────
+
+  it('shows loading overlay while verifyCoachPin is in progress', async () => {
+    let resolveVerify!: (value: unknown) => void;
+    const pendingVerify = new Promise(res => { resolveVerify = res; });
+    mockVerifyCoachPin.mockReturnValue(pendingVerify as ReturnType<typeof mockVerifyCoachPin>);
+
+    render(<CoachLoginDialog {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText('Enter PIN code'), '1234');
+    await userEvent.click(screen.getByRole('button', { name: 'Verify' }));
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+
+    resolveVerify({ id: '1', firstname: 'John', lastname: 'Doe', alias: '', pin: '1234', created_at: '', last_activity: '' });
+  });
+
+  it('hides loading overlay after verifyCoachPin completes successfully', async () => {
+    let resolveVerify!: (value: unknown) => void;
+    const pendingVerify = new Promise(res => { resolveVerify = res; });
+    mockVerifyCoachPin.mockReturnValue(pendingVerify as ReturnType<typeof mockVerifyCoachPin>);
+
+    render(<CoachLoginDialog {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText('Enter PIN code'), '1234');
+    await userEvent.click(screen.getByRole('button', { name: 'Verify' }));
+
+    resolveVerify({ id: '1', firstname: 'John', lastname: 'Doe', alias: '', pin: '1234', created_at: '', last_activity: '' });
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
+  });
+
+  it('hides loading overlay after verifyCoachPin fails', async () => {
+    let rejectVerify!: (err: Error) => void;
+    const pendingVerify = new Promise((_res, rej) => { rejectVerify = rej; });
+    mockVerifyCoachPin.mockReturnValue(pendingVerify as ReturnType<typeof mockVerifyCoachPin>);
+
+    render(<CoachLoginDialog {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText('Enter PIN code'), '9999');
+    await userEvent.click(screen.getByRole('button', { name: 'Verify' }));
+
+    rejectVerify(new Error('no_match_found'));
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
+  });
 });

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -41,5 +41,6 @@
   "adminLogin.cancel": "Cancel",
   "adminLogin.incorrectPassword": "Incorrect password. Try again.",
   "adminView.title": "Administrator",
-  "adminView.backToMain": "Back to main"
+  "adminView.backToMain": "Back to main",
+  "loading.overlay": "Loading"
 }

--- a/web/src/locales/fi.json
+++ b/web/src/locales/fi.json
@@ -41,5 +41,6 @@
   "adminLogin.cancel": "Peruuta",
   "adminLogin.incorrectPassword": "Väärä salasana. Yritä uudelleen.",
   "adminView.title": "Ylläpitäjä",
-  "adminView.backToMain": "Takaisin etusivulle"
+  "adminView.backToMain": "Takaisin etusivulle",
+  "loading.overlay": "Ladataan"
 }

--- a/web/src/shared/components/LoadingOverlay/LoadingOverlay.module.css
+++ b/web/src/shared/components/LoadingOverlay/LoadingOverlay.module.css
@@ -1,0 +1,33 @@
+/**
+ * @copyright 2026 Jouni Sipola by OQM. All rights reserved.
+ * Permission granted for personal/internal use only. Commercial
+ * use prohibited except by copyright holder. See LICENSE for details.
+ */
+
+/**
+ * @description CSS Module styles for LoadingOverlay — dimmed full-screen overlay with a centered spinner.
+ */
+.loadingOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}
+
+.spinner {
+  width: 48px;
+  height: 48px;
+  border: 5px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/web/src/shared/components/LoadingOverlay/LoadingOverlay.tsx
+++ b/web/src/shared/components/LoadingOverlay/LoadingOverlay.tsx
@@ -1,0 +1,40 @@
+/**
+ * @copyright 2026 Jouni Sipola by OQM. All rights reserved.
+ * Permission granted for personal/internal use only. Commercial
+ * use prohibited except by copyright holder. See LICENSE for details.
+ */
+
+/**
+ * @description Full-screen dimmed overlay with a centered spinner.
+ *   Rendered during API operations to block user interaction and signal loading.
+ *   @see skills/SKILL.wire-react-to-gas.md
+ */
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import styles from './LoadingOverlay.module.css';
+
+export interface LoadingOverlayProps {
+  /** Whether the overlay is visible. */
+  visible: boolean;
+}
+
+/**
+ * Renders a dimmed full-screen overlay with a spinner when `visible` is true.
+ * Uses ARIA attributes to communicate loading state to screen readers.
+ */
+export function LoadingOverlay({ visible }: LoadingOverlayProps) {
+  const { t } = useTranslation();
+
+  if (!visible) return null;
+
+  return (
+    <div
+      className={styles.loadingOverlay}
+      role="status"
+      aria-live="polite"
+      aria-label={t('loading.overlay')}
+    >
+      <div className={styles.spinner} />
+    </div>
+  );
+}

--- a/web/src/shared/components/LoadingOverlay/__tests__/LoadingOverlay.test.tsx
+++ b/web/src/shared/components/LoadingOverlay/__tests__/LoadingOverlay.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * @copyright 2026 Jouni Sipola by OQM. All rights reserved.
+ * Permission granted for personal/internal use only. Commercial
+ * use prohibited except by copyright holder. See LICENSE for details.
+ */
+
+/**
+ * @description Tests for LoadingOverlay — validates rendering, accessibility, and visibility toggling.
+ *   Written before implementation (TDD).
+ */
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import '../../../../lib/i18n';
+import { LoadingOverlay } from '../LoadingOverlay';
+
+describe('LoadingOverlay', () => {
+  it('renders nothing when visible=false', () => {
+    const { container } = render(<LoadingOverlay visible={false} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders when visible=true', () => {
+    render(<LoadingOverlay visible={true} />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('has aria-label "Loading" for screen readers', () => {
+    render(<LoadingOverlay visible={true} />);
+    expect(screen.getByRole('status')).toHaveAttribute('aria-label', 'Loading');
+  });
+
+  it('has aria-live="polite" for screen readers', () => {
+    render(<LoadingOverlay visible={true} />);
+    expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('renders the spinner element', () => {
+    render(<LoadingOverlay visible={true} />);
+    // The spinner is a div inside the overlay
+    const overlay = screen.getByRole('status');
+    expect(overlay.firstElementChild).not.toBeNull();
+  });
+});

--- a/web/src/shared/components/RegisterPinDialog/RegisterPinDialog.tsx
+++ b/web/src/shared/components/RegisterPinDialog/RegisterPinDialog.tsx
@@ -13,6 +13,7 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
+import { LoadingOverlay } from '../LoadingOverlay/LoadingOverlay';
 import styles from './RegisterPinDialog.module.css';
 
 const PIN_PATTERN = /^\d{4,6}$/;
@@ -298,6 +299,8 @@ export function RegisterPinDialog({
           </div>
         </div>
       )}
+
+      <LoadingOverlay visible={isSubmitting} />
     </>
   );
 }

--- a/web/src/shared/components/RegisterPinDialog/__tests__/RegisterPinDialog.test.tsx
+++ b/web/src/shared/components/RegisterPinDialog/__tests__/RegisterPinDialog.test.tsx
@@ -346,4 +346,46 @@ describe('RegisterPinDialog', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(defaultProps.onCancel).toHaveBeenCalledOnce();
   });
+
+  // ── Loading overlay (OQM-0005) ────────────────────────────────────────────
+
+  it('shows loading overlay while API call is in progress', async () => {
+    let resolveRegister!: () => void;
+    const pendingRegister = new Promise<void>(res => { resolveRegister = res; });
+    defaultProps.onRegister.mockReturnValue(pendingRegister);
+
+    render(<RegisterPinDialog {...defaultProps} />);
+    await fillValidForm();
+    await userEvent.click(screen.getByRole('button', { name: 'Register' }));
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+
+    resolveRegister();
+  });
+
+  it('hides loading overlay after API call completes', async () => {
+    let resolveRegister!: () => void;
+    const pendingRegister = new Promise<void>(res => { resolveRegister = res; });
+    defaultProps.onRegister.mockReturnValue(pendingRegister);
+
+    render(<RegisterPinDialog {...defaultProps} />);
+    await fillValidForm();
+    await userEvent.click(screen.getByRole('button', { name: 'Register' }));
+
+    resolveRegister();
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
+  });
+
+  it('hides loading overlay after API call fails', async () => {
+    let rejectRegister!: (err: Error) => void;
+    const pendingRegister = new Promise<void>((_res, rej) => { rejectRegister = rej; });
+    defaultProps.onRegister.mockReturnValue(pendingRegister);
+
+    render(<RegisterPinDialog {...defaultProps} />);
+    await fillValidForm();
+    await userEvent.click(screen.getByRole('button', { name: 'Register' }));
+
+    rejectRegister(new Error('Network error'));
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
+  });
 });


### PR DESCRIPTION
…OQM-0005)

- Create shared LoadingOverlay component with CSS spinner animation
- Add ARIA attributes (role=status, aria-live=polite, aria-label) for accessibility
- Apply LoadingOverlay to RegisterPinDialog during PIN registration API call
- Add isVerifying state to CoachLoginDialog; apply LoadingOverlay during PIN verification
- Add loading.overlay i18n key in en.json and fi.json
- Write TDD tests: LoadingOverlay unit tests + spinner tests in both dialog test suites
- All 127 tests pass

Closes #10

## Summary
- Linked issue: #

## Checklist
- [ ] Tests added/updated and passing
- [ ] No secrets committed
- [ ] API contract adhered to
- [ ] Updated docs/skills if schema or flows changed
