### PR TITLE
feat: OQM-0008 register coach for session with real backend API

### DIFF
--- a/gas/Code.gs
+++ b/gas/Code.gs
@@ -7,6 +7,7 @@
  *  - POST { route: "createItem", payload: { name, email } }
  *  - POST { route: "registerCoachPin", payload: { firstname, lastname, alias, pin } } — register a new coach PIN code (OQM-0003)
  *  - POST { route: "verifyCoachPin", payload: { pin } } — verify a coach PIN against coach_login sheet (OQM-0004)
+ *  - POST { route: "registerCoachForSession", payload: { firstname, lastname, session_type, date, start_time?, end_time? } } — register coach for a session (OQM-0008)
  */
 
 const SHEET_ID = PropertiesService.getScriptProperties().getProperty('SHEET_ID');
@@ -63,6 +64,16 @@ function doPost(e) {
         return json_({ ok: false, error: 'no_match_found' });
       }
       return json_({ ok: true, data: coachData });
+    }
+    if (route === 'registerCoachForSession') {
+      const result = registerCoachForSession_(payload);
+      if (result.alreadyTaken) {
+        return json_({ ok: false, error: 'already_taken' });
+      }
+      if (result.unknownCoach) {
+        return json_({ ok: false, error: 'unknown_coach' });
+      }
+      return json_({ ok: true, data: { id: result.id } });
     }
     return json_({ ok: false, error: 'Unknown route' });
   } catch (err) {
@@ -216,6 +227,56 @@ function verifyCoachPin_(payload) {
     created_at: String(row[5]),
     last_activity: String(row[6])
   };
+}
+
+/**
+ * Register a coach for a specific session.
+ * Validates that the coach exists in coach_login and that no coach is already registered for the session.
+ * On success, appends a row to coach_registrations and returns the new row id.
+ * Returns { alreadyTaken: true } if a coach is already registered for the session+date.
+ * Returns { unknownCoach: true } if the coach is not in coach_login.
+ * Schema: id, first_name, last_name, session_type, date, realized, start_time, end_time, created_at, updated_at (columns A–J)
+ * See SKILL.sheet-schema.md for full schema definition.
+ * See SKILL.wire-react-to-gas.md for API contract (OQM-0008).
+ */
+function registerCoachForSession_(payload) {
+  if (!payload || !payload.firstname || !payload.lastname || !payload.session_type || !payload.date) {
+    throw new Error('Missing required fields: firstname, lastname, session_type, date');
+  }
+
+  // Check coach exists in coach_login (columns B=firstname, C=lastname)
+  const coachRows = getSheetData('coach_login');
+  const coachExists = coachRows.some(r =>
+    String(r[1]).trim().toLowerCase() === payload.firstname.trim().toLowerCase() &&
+    String(r[2]).trim().toLowerCase() === payload.lastname.trim().toLowerCase()
+  );
+  if (!coachExists) {
+    return { unknownCoach: true };
+  }
+
+  // Check if session already has a registered coach (session_type + date with realized=true)
+  const coachRegRows = getSheetData('coach_registrations');
+  const tz = Session.getScriptTimeZone();
+  const sessionTypeUpper = payload.session_type.toUpperCase();
+  const alreadyRegistered = coachRegRows.some(r => {
+    const regSessionType = String(r[3] || '').toUpperCase();
+    const regDate = timeToStr(r[4], tz, 'yyyy-MM-dd');
+    const realized = r.length >= 6 ? getBooleanValue(r[5]) : true;
+    return regSessionType === sessionTypeUpper && regDate === payload.date && realized;
+  });
+  if (alreadyRegistered) {
+    return { alreadyTaken: true };
+  }
+
+  // Append row to coach_registrations
+  const sh = getSheetByName('coach_registrations');
+  const id = Utilities.getUuid();
+  const now = new Date().toISOString();
+  const startTime = payload.start_time || '';
+  const endTime = payload.end_time || '';
+  sh.appendRow([id, payload.firstname, payload.lastname, payload.session_type, payload.date, true, startTime, endTime, now, now]);
+
+  return { id };
 }
 
 function getBooleanValue(value) {
@@ -492,8 +553,8 @@ function getCoachSessions_() {
           return; // Camp session outside of session window
         }
         var sessionName = String(r[2]);
-        var startTime = Utilities.formatDate(r[4], tz, 'yyyy-MM-dd');
-        var endTime = Utilities.formatDate(r[5], tz, 'yyyy-MM-dd');
+        var startTime = timeToStr(r[4], tz, 'HH:mm');
+        var endTime = timeToStr(r[5], tz, 'HH:mm');
 
         // Remove any regular session with same date from sessions
         sessions = sessions.filter(function(s) {

--- a/skills/SKILL.wire-react-to-gas.md
+++ b/skills/SKILL.wire-react-to-gas.md
@@ -7,6 +7,7 @@
 - POST `{ route: "createItem", payload, token }` → append row
 - POST `{ route: "registerCoachPin", payload, token }` → register coach PIN (OQM-0003)
 - POST `{ route: "verifyCoachPin", payload, token }` → verify coach PIN, return coach data (OQM-0004)
+- POST `{ route: "registerCoachForSession", payload, token }` → register coach for a session (OQM-0008)
 - Response JSON shape: `{ ok: true, data } | { ok: false, error }`
 
 ## Settings parameters used by the frontend
@@ -211,6 +212,82 @@ API must accept a language parameter and return localized responses where applic
 |-------------|---------------------------------|----------------------|
 | `coach_pwd` | Password for coach login        | CoachLoginDialog     |
 | `admin_pwd` | Password for admin login        | AdminLoginDialog     |
+
+## registerCoachForSession (OQM-0008)
+
+### Request
+```json
+{
+  "route": "registerCoachForSession",
+  "payload": {
+    "firstname": "string (required)",
+    "lastname":  "string (required)",
+    "session_type": "string (required)",
+    "date":      "string (required, YYYY-MM-DD)",
+    "start_time": "string (optional, HH:MM — only for free/sparring sessions)",
+    "end_time":   "string (optional, HH:MM — only for free/sparring sessions)"
+  },
+  "token": "string"
+}
+```
+
+### Response (success)
+```json
+{ "ok": true, "data": { "id": "uuid" } }
+```
+
+### Response (session already taken)
+```json
+{ "ok": false, "error": "already_taken" }
+```
+
+### Response (unknown coach)
+```json
+{ "ok": false, "error": "unknown_coach" }
+```
+
+### Error cases
+| Error            | Meaning                                                         |
+|------------------|-----------------------------------------------------------------|
+| `already_taken`  | A coach is already registered for this session on this date     |
+| `unknown_coach`  | Coach (firstname + lastname) not found in `coach_login` sheet   |
+| `Unauthorized`   | Invalid or missing API token                                    |
+| `Missing required fields: ...` | Payload validation failure                    |
+
+### Frontend API function
+```ts
+/** Payload for registering a coach for a session. */
+type RegisterCoachForSessionPayload = {
+  firstname: string;
+  lastname: string;
+  session_type: string;
+  date: string;
+  start_time?: string;
+  end_time?: string;
+};
+
+/**
+ * Register a coach for a specific session.
+ * Returns the newly created registration id on success.
+ * Throws Error('already_taken') if the session already has a registered coach.
+ * Throws Error('unknown_coach') if the coach is not found in coach_login.
+ * Throws other Errors on network/service failures.
+ */
+export async function registerCoachForSession(payload: RegisterCoachForSessionPayload): Promise<string> {
+  const base = import.meta.env.VITE_GAS_BASE_URL as string;
+  const token = import.meta.env.VITE_API_TOKEN as string;
+  if (!base) throw new Error('VITE_GAS_BASE_URL is not configured');
+  const res = await fetch(base, {
+    method: 'POST',
+    redirect: 'follow',
+    headers: { 'Content-Type': 'text/plain;charset=utf-8' },
+    body: JSON.stringify({ route: 'registerCoachForSession', payload, token }),
+  });
+  const json = await res.json();
+  if (!json.ok) throw new Error(json.error || 'Registration failed');
+  return json.data.id as string;
+}
+```
 
 ## Frontend fetch patterns
 ```ts

--- a/user_stories/coach/features/OQM-0008-register-a-coach-for-a-session/OQM-0008-register-a-coach-for-a-session.md
+++ b/user_stories/coach/features/OQM-0008-register-a-coach-for-a-session/OQM-0008-register-a-coach-for-a-session.md
@@ -1,0 +1,101 @@
+**Title:** Register a coach for a session
+
+**Description:**  
+Enable a logged-in coach to register for an available session via the Coach Page. Registration is confirmed through a dialog, and the result is communicated to the user.
+
+**User Story:**  
+As a coach, I want to register for a session so that my participation is recorded and confirmed.
+
+**Preconditions:**  
+- User is logged in to Coach Page using PIN code  
+- At least one Session card with no registered coach are available
+
+**Operation Flow:**  
+1. User clicks "Register" button on a session card  
+2. Confirmation dialog appears  
+3. User clicks "Confirm" → registration sent to backend, result shown  
+4. User clicks "Cancel" → dialog closes, cancellation toast shown
+
+**Dialog Content:**
+- The ConfirmCoachRegistrationDialog displays:
+    - Confirmation text: "Do you register as coach for this session?"
+    - Session information 
+        - session type
+        - date
+        - time
+    - Coach name or identifier
+    - Buttons: Confirm, Cancel
+
+**Data Handling:**
+1. GAS function first checks that there isn't already registered coach for the session
+    - if one is found then returns with error code `already_taken`
+2. GAS function checks that the coach is listed in `coach_login` sheet
+    - if no match is found from coach_login sheet returns an error code `unknown_coach`
+3. GAS function inserts following data into the `coach_registrations` sheet:
+    - id 
+        - generated UUIDv4, unique for the sheet
+    - first_name
+        - From request, firstname of the coach
+    - last_name
+        - From request, lastname of the coach
+    - session_type
+        - From request
+    - date
+        - from request
+        - the date when session is being held
+        - in format 'YYYY-MM-DD'
+    - realized
+        - boolean, value set to true by default
+        - indicates whether the coach will coach/has coached the training session
+        - may be set to false if coach is removed from the session (will be implemented later)
+    - start_time
+        - from request
+        - set only if session_type is 'free/sparring'
+        - start time of the session for that day
+        - in format 'HH:MM'
+    - end_time
+        - from request
+        - only if session_type is 'free/sparring'
+        - end time of the session for that day
+        - in format 'HH:MM'
+    - created_at
+         - current date and time in ISO 8601 format
+3. returns id of the appended row or an error if operation fails
+
+**User Feedback:**
+Messages shown to the user:
+- Toast message: "Registration ongoing. Please wait." when registration operation starts
+- Success: "Registration successful!"
+- Error: "Registration failed. Please try again."
+- already_taken error: "Session already has a registered coach. Refresh page."
+- unknown_coach error: "Unknown coach. Contact system administrator."
+- Cancel: "Registration cancelled."
+- When registration succesful the Session Card's
+    - background color changes to green
+    - button changes to "Remove" button
+    - Coach name is shown in the Session Card
+
+**Test Cases:**  
+- Coach can successfully register for only one session at the time
+- Coach can register to another session after cancelling before confirmation
+- Coach can register to another session after succesful registration
+- Coach sees notifications about the progress of the operation as well as Session Card changes when succesfully registered to a session
+- Coach receives error message if registration fails 
+- Coach can cancel registration before confirmation and sees cancellation notification
+
+**Acceptance Criteria:**  
+- Clicking "Register" on a session card opens a confirmation dialog
+- Registration data must be validated before sending
+- Confirming registration sends data to backend (GAS API) and updates `coach_registrations` sheet  
+- User receives a success or failure message after registration attempt  
+- Cancelling registration closes the dialog and shows a cancellation toast
+- There is no limitations to how many sessions the user can register but only one registration at the time
+- There is no limitations to how many session registrations the user can cancel before confirm
+
+**Linked Files/Branches:**  
+- [CoachPage.tsx](web/src/pages/Coach/CoachPage.tsx)
+- [ConfirmCoachRegistrationDialog.tsx](web/src/features/coach/components/ConfirmCoachRegistrationDialog.tsx)
+- [SessionCard.tsx](web/src/features/coach/components/SessionCard.tsx)
+- [coach_registrations sheet schema](skills/SKILL.sheet-schema.md)  
+- GAS API implementation ([Code.gs](gas/Code.gs))
+- [SKILL.wire-react-to-gas.md](skills/SKILL.wire-react-to-gas.md)

--- a/user_stories/coach/features/OQM-0008-register-a-coach-for-a-session/prompt.md
+++ b/user_stories/coach/features/OQM-0008-register-a-coach-for-a-session/prompt.md
@@ -1,0 +1,5 @@
+Implement the feature described in GitHub issue #16:
+- Follow [SKILL.wire-react-to-gas.md](http://_vscodecontentref_/0) for API contract
+- Use [SKILL.sheet-schema.md](http://_vscodecontentref_/1) for data structure
+- Apply all relevant instructions from [copilot-instructions.md](http://_vscodecontentref_/2) and [frontend.instructions.md](http://_vscodecontentref_/3) and [backend.instructions.md](http://_vscodecontentref_/4)
+- Use TDD and update documentation as required

--- a/user_stories/templates/comprehensive-issue-template.md
+++ b/user_stories/templates/comprehensive-issue-template.md
@@ -1,0 +1,34 @@
+**Title:** [Feature or Bug Title]
+
+**Description:**  
+[Brief summary of the feature or problem.]
+
+**User Story:**  
+As a [role], I want [action] so that [goal].
+
+**Preconditions:**  
+- [List any preconditions or requirements.]
+
+**Operation Flow:**  
+1. [Step-by-step flow of the operation.]
+
+**Dialog/Page Content:**
+[Define dialog/page content.]
+
+**Data Handling:**
+[Describe backend data handling steps.]
+
+**User Feedback:**
+[Describe messages/notifications/errors as well as possible changes in UI.]
+
+**Test Cases:**  
+- [Define how the feature/bug will be tested.]
+
+**Acceptance Criteria:**  
+- [List requirements that must be met for completion.]
+
+**Linked Files/Branches:**  
+- [Reference related files, branches, or PRs.]
+
+**Additional Context:**  
+- [Screenshots, diagrams, or links to relevant documentation.]

--- a/web/src/features/coach/api/__tests__/coach.api.test.ts
+++ b/web/src/features/coach/api/__tests__/coach.api.test.ts
@@ -189,3 +189,74 @@ describe('getCoachSessions', () => {
     await expect(getCoachSessions()).rejects.toThrow('Failed to fetch sessions');
   });
 });
+
+import { registerCoachForSession } from '../coach.api';
+
+describe('registerCoachForSession', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_GAS_BASE_URL', BASE);
+    vi.stubEnv('VITE_API_TOKEN', TOKEN);
+    mockFetch.mockReset();
+  });
+
+  it('throws when VITE_GAS_BASE_URL is not configured', async () => {
+    vi.stubEnv('VITE_GAS_BASE_URL', '');
+    await expect(
+      registerCoachForSession({ firstname: 'John', lastname: 'Doe', session_type: 'Kickboxing', date: '2026-03-09' })
+    ).rejects.toThrow('VITE_GAS_BASE_URL is not configured');
+  });
+
+  it('sends a POST request with correct shape', async () => {
+    mockFetch.mockResolvedValue({ json: async () => ({ ok: true, data: { id: 'new-uuid' } }) });
+    const payload = { firstname: 'John', lastname: 'Doe', session_type: 'Kickboxing', date: '2026-03-09' };
+    await registerCoachForSession(payload);
+    expect(mockFetch).toHaveBeenCalledWith(
+      BASE,
+      expect.objectContaining({
+        method: 'POST',
+        redirect: 'follow',
+        headers: { 'Content-Type': 'text/plain;charset=utf-8' },
+        body: JSON.stringify({ route: 'registerCoachForSession', payload, token: TOKEN }),
+      })
+    );
+  });
+
+  it('sends optional start_time and end_time for free/sparring sessions', async () => {
+    mockFetch.mockResolvedValue({ json: async () => ({ ok: true, data: { id: 'new-uuid' } }) });
+    const payload = { firstname: 'John', lastname: 'Doe', session_type: 'free/sparring', date: '2026-03-09', start_time: '10:00', end_time: '11:30' };
+    await registerCoachForSession(payload);
+    expect(mockFetch).toHaveBeenCalledWith(
+      BASE,
+      expect.objectContaining({
+        body: JSON.stringify({ route: 'registerCoachForSession', payload, token: TOKEN }),
+      })
+    );
+  });
+
+  it('returns registration id when backend returns ok: true', async () => {
+    mockFetch.mockResolvedValue({ json: async () => ({ ok: true, data: { id: 'reg-123' } }) });
+    const result = await registerCoachForSession({ firstname: 'John', lastname: 'Doe', session_type: 'Kickboxing', date: '2026-03-09' });
+    expect(result).toBe('reg-123');
+  });
+
+  it('throws "already_taken" when backend returns that error', async () => {
+    mockFetch.mockResolvedValue({ json: async () => ({ ok: false, error: 'already_taken' }) });
+    await expect(
+      registerCoachForSession({ firstname: 'John', lastname: 'Doe', session_type: 'Kickboxing', date: '2026-03-09' })
+    ).rejects.toThrow('already_taken');
+  });
+
+  it('throws "unknown_coach" when backend returns that error', async () => {
+    mockFetch.mockResolvedValue({ json: async () => ({ ok: false, error: 'unknown_coach' }) });
+    await expect(
+      registerCoachForSession({ firstname: 'John', lastname: 'Doe', session_type: 'Kickboxing', date: '2026-03-09' })
+    ).rejects.toThrow('unknown_coach');
+  });
+
+  it('throws with backend error message on other errors', async () => {
+    mockFetch.mockResolvedValue({ json: async () => ({ ok: false, error: 'Unauthorized' }) });
+    await expect(
+      registerCoachForSession({ firstname: 'John', lastname: 'Doe', session_type: 'Kickboxing', date: '2026-03-09' })
+    ).rejects.toThrow('Unauthorized');
+  });
+});

--- a/web/src/features/coach/api/coach.api.ts
+++ b/web/src/features/coach/api/coach.api.ts
@@ -11,7 +11,7 @@
  *   @see skills/SKILL.wire-react-to-gas.md
  */
 import type { RegisterPinData } from '../../../shared/components/RegisterPinDialog/RegisterPinDialog';
-import type { CoachData, SessionItem } from '../types';
+import type { CoachData, SessionItem, RegisterCoachForSessionPayload } from '../types';
 
 /**
  * Register a new coach PIN code by posting to the GAS backend.
@@ -71,4 +71,28 @@ export async function getCoachSessions(): Promise<SessionItem[]> {
   const json = await res.json();
   if (!json.ok) throw new Error(json.error || 'Failed to fetch sessions');
   return json.data as SessionItem[];
+}
+
+/**
+ * Register a coach for a specific session.
+ * POST { route: "registerCoachForSession", payload: RegisterCoachForSessionPayload, token }
+ * Returns the new registration id on success.
+ * Throws Error('already_taken') if a coach is already registered for that session and date.
+ * Throws Error('unknown_coach') if the coach is not found in coach_login.
+ * Throws other Errors for network/service failures.
+ * @see skills/SKILL.wire-react-to-gas.md
+ */
+export async function registerCoachForSession(payload: RegisterCoachForSessionPayload): Promise<string> {
+  const base = import.meta.env.VITE_GAS_BASE_URL as string;
+  const token = import.meta.env.VITE_API_TOKEN as string;
+  if (!base) throw new Error('VITE_GAS_BASE_URL is not configured');
+  const res = await fetch(base, {
+    method: 'POST',
+    redirect: 'follow',
+    headers: { 'Content-Type': 'text/plain;charset=utf-8' },
+    body: JSON.stringify({ route: 'registerCoachForSession', payload, token }),
+  });
+  const json = await res.json();
+  if (!json.ok) throw new Error(json.error || 'Registration failed');
+  return json.data.id as string;
 }

--- a/web/src/features/coach/components/ConfirmCoachRegistrationDialog.tsx
+++ b/web/src/features/coach/components/ConfirmCoachRegistrationDialog.tsx
@@ -5,46 +5,127 @@
  */
 
 /**
- * @description Dummy confirmation dialog shown when the coach clicks 'Register' on a session card.
- *   No backend call is made — this is a placeholder dialog (OQM-0007).
+ * @description Confirmation dialog shown when a coach clicks 'Register' on a session card (OQM-0008).
+ *   Displays session details and coach name, calls the GAS backend to register the coach,
+ *   shows loading state during the API call, and notifies the parent on success or cancellation.
  *   Uses MUI Dialog for accessible and consistent UI.
+ *   @see skills/SKILL.wire-react-to-gas.md
  */
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogActions from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import { LoadingOverlay } from '../../../shared/components/LoadingOverlay/LoadingOverlay';
+import { registerCoachForSession } from '../api/coach.api';
+import type { SessionItem, CoachData } from '../types';
 
 export interface ConfirmCoachRegistrationDialogProps {
   open: boolean;
-  onConfirm: () => void;
+  /** The session the coach wants to register for. */
+  session: SessionItem | null;
+  /** The authenticated coach; undefined when logged in via password only. */
+  coachData?: CoachData;
+  /** Called with the new registration id after a successful registration. */
+  onSuccess: (registrationId: string) => void;
+  /** Called when the user clicks Cancel. */
   onCancel: () => void;
 }
 
-/** Dummy modal asking the coach to confirm registration for a session. */
+/** Format 'YYYY-MM-DD' as 'DD.MM.YYYY' for display. */
+function formatDate(dateStr: string): string {
+  const [year, month, day] = dateStr.split('-');
+  return `${day}.${month}.${year}`;
+}
+
+/** Modal confirming coach registration for a session — calls the GAS backend on confirm. */
 export function ConfirmCoachRegistrationDialog({
   open,
-  onConfirm,
+  session,
+  coachData,
+  onSuccess,
   onCancel,
 }: ConfirmCoachRegistrationDialogProps) {
   const { t } = useTranslation();
+  const [loading, setLoading] = useState(false);
+
+  async function handleConfirm() {
+    if (!session || !coachData || loading) return;
+    setLoading(true);
+    toast(t('coachQuickRegistration.registrationOngoing'));
+    try {
+      const payload = {
+        firstname: coachData.firstname,
+        lastname: coachData.lastname,
+        session_type: session.session_type,
+        date: session.date,
+        ...(session.is_free_sparring && {
+          start_time: session.start_time,
+          end_time: session.end_time,
+        }),
+      };
+      const registrationId = await registerCoachForSession(payload);
+      toast.success(t('coachQuickRegistration.registrationSuccess'));
+      onSuccess(registrationId);
+    } catch (err) {
+      const code = err instanceof Error ? err.message : '';
+      if (code === 'already_taken') {
+        toast.error(t('coachQuickRegistration.alreadyTaken'));
+      } else if (code === 'unknown_coach') {
+        toast.error(t('coachQuickRegistration.unknownCoach'));
+      } else {
+        toast.error(t('coachQuickRegistration.registrationFailed'));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const coachName = coachData?.alias || (coachData ? `${coachData.firstname} ${coachData.lastname}` : '');
 
   return (
     <Dialog open={open} onClose={onCancel} aria-labelledby="confirm-register-title">
+      <LoadingOverlay visible={loading} />
       <DialogTitle id="confirm-register-title">
         {t('coachQuickRegistration.confirmRegisterTitle')}
       </DialogTitle>
       <DialogContent>
         <DialogContentText>
-          {t('coachQuickRegistration.confirmRegisterMessage')}
+          {t('coachQuickRegistration.confirmRegisterQuestion')}
         </DialogContentText>
+        {session && (
+          <>
+            <Typography variant="body2" sx={{ mt: 1 }}>
+              <strong>{t('coachQuickRegistration.sessionTypeLabel')}:</strong>{' '}
+              {session.session_type_alias || session.session_type}
+            </Typography>
+            <Typography variant="body2">
+              <strong>{t('coachQuickRegistration.sessionDateLabel')}:</strong>{' '}
+              {formatDate(session.date)}
+            </Typography>
+            <Typography variant="body2">
+              <strong>{t('coachQuickRegistration.sessionTimeLabel')}:</strong>{' '}
+              {session.start_time} – {session.end_time}
+            </Typography>
+          </>
+        )}
+        {coachName && (
+          <Typography variant="body2">
+            <strong>{t('coachQuickRegistration.coachNameLabel')}:</strong>{' '}
+            {coachName}
+          </Typography>
+        )}
       </DialogContent>
       <DialogActions>
-        <Button onClick={onCancel}>{t('coachQuickRegistration.cancel')}</Button>
-        <Button onClick={onConfirm} variant="contained" color="primary">
+        <Button onClick={onCancel} disabled={loading}>
+          {t('coachQuickRegistration.cancel')}
+        </Button>
+        <Button onClick={handleConfirm} variant="contained" color="primary" disabled={loading || !session || !coachData}>
           {t('coachQuickRegistration.confirm')}
         </Button>
       </DialogActions>

--- a/web/src/features/coach/components/__tests__/ConfirmCoachRegistrationDialog.test.tsx
+++ b/web/src/features/coach/components/__tests__/ConfirmCoachRegistrationDialog.test.tsx
@@ -5,24 +5,63 @@
  */
 
 /**
- * @description Tests for ConfirmCoachRegistrationDialog — dummy confirmation dialog.
+ * @description Tests for ConfirmCoachRegistrationDialog — real registration confirmation dialog (OQM-0008).
  *   Written before implementation (TDD).
  */
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import '../../../../lib/i18n';
 import { ConfirmCoachRegistrationDialog } from '../ConfirmCoachRegistrationDialog';
+import type { SessionItem, CoachData } from '../../types';
+
+vi.mock('../../api/coach.api', () => ({
+  registerCoachForSession: vi.fn(),
+}));
+
+import { registerCoachForSession } from '../../api/coach.api';
+const mockRegisterCoachForSession = vi.mocked(registerCoachForSession);
+
+const mockSession: SessionItem = {
+  id: 'ws-1_2026-03-09',
+  session_type: 'Kickboxing',
+  session_type_alias: 'Nyrkkeilyharjoitus',
+  date: '2026-03-09',
+  start_time: '18:00',
+  end_time: '19:30',
+  location: 'Gym A',
+  coach_firstname: '',
+  coach_lastname: '',
+  coach_alias: '',
+  registration_id: '',
+  is_free_sparring: false,
+};
+
+const mockCoachData: CoachData = {
+  id: 'coach-1',
+  firstname: 'John',
+  lastname: 'Doe',
+  alias: 'JD',
+  pin: '1234',
+  created_at: '2026-01-01T00:00:00Z',
+  last_activity: '',
+};
 
 const defaultProps = {
   open: true,
-  onConfirm: vi.fn(),
+  session: mockSession,
+  coachData: mockCoachData,
+  onSuccess: vi.fn(),
   onCancel: vi.fn(),
 };
 
 describe('ConfirmCoachRegistrationDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('does not render when open=false', () => {
     render(<ConfirmCoachRegistrationDialog {...defaultProps} open={false} />);
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
@@ -38,9 +77,29 @@ describe('ConfirmCoachRegistrationDialog', () => {
     expect(screen.getByText('Confirm Registration')).toBeInTheDocument();
   });
 
-  it('renders confirmation message', () => {
+  it('renders confirmation question', () => {
     render(<ConfirmCoachRegistrationDialog {...defaultProps} />);
-    expect(screen.getByText('Register for this session?')).toBeInTheDocument();
+    expect(screen.getByText(/Do you register as coach for this session\?/i)).toBeInTheDocument();
+  });
+
+  it('renders session type alias', () => {
+    render(<ConfirmCoachRegistrationDialog {...defaultProps} />);
+    expect(screen.getByText(/Nyrkkeilyharjoitus/i)).toBeInTheDocument();
+  });
+
+  it('renders session date', () => {
+    render(<ConfirmCoachRegistrationDialog {...defaultProps} />);
+    expect(screen.getByText(/09\.03\.2026/)).toBeInTheDocument();
+  });
+
+  it('renders session time', () => {
+    render(<ConfirmCoachRegistrationDialog {...defaultProps} />);
+    expect(screen.getByText(/18:00/)).toBeInTheDocument();
+  });
+
+  it('renders coach alias', () => {
+    render(<ConfirmCoachRegistrationDialog {...defaultProps} />);
+    expect(screen.getByText(/JD/)).toBeInTheDocument();
   });
 
   it('renders Confirm button', () => {
@@ -53,17 +112,59 @@ describe('ConfirmCoachRegistrationDialog', () => {
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
   });
 
-  it('calls onConfirm when Confirm is clicked', async () => {
-    const onConfirm = vi.fn();
-    render(<ConfirmCoachRegistrationDialog {...defaultProps} onConfirm={onConfirm} />);
-    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
-    expect(onConfirm).toHaveBeenCalledOnce();
-  });
-
   it('calls onCancel when Cancel is clicked', async () => {
     const onCancel = vi.fn();
     render(<ConfirmCoachRegistrationDialog {...defaultProps} onCancel={onCancel} />);
     await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(onCancel).toHaveBeenCalledOnce();
   });
+
+  it('calls registerCoachForSession with correct payload when Confirm is clicked', async () => {
+    mockRegisterCoachForSession.mockResolvedValue('reg-123');
+    render(<ConfirmCoachRegistrationDialog {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(mockRegisterCoachForSession).toHaveBeenCalledWith({
+      firstname: 'John',
+      lastname: 'Doe',
+      session_type: 'Kickboxing',
+      date: '2026-03-09',
+    });
+  });
+
+  it('calls onSuccess with registrationId after successful registration', async () => {
+    mockRegisterCoachForSession.mockResolvedValue('reg-123');
+    const onSuccess = vi.fn();
+    render(<ConfirmCoachRegistrationDialog {...defaultProps} onSuccess={onSuccess} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledWith('reg-123'));
+  });
+
+  it('includes start_time and end_time for free/sparring sessions', async () => {
+    const freeSession: SessionItem = { ...mockSession, session_type: 'free/sparring', is_free_sparring: true, start_time: '10:00', end_time: '11:30' };
+    mockRegisterCoachForSession.mockResolvedValue('reg-456');
+    render(<ConfirmCoachRegistrationDialog {...defaultProps} session={freeSession} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(mockRegisterCoachForSession).toHaveBeenCalledWith(
+      expect.objectContaining({ start_time: '10:00', end_time: '11:30' })
+    );
+  });
+
+  it('disables Confirm button and shows loading overlay during API call', async () => {
+    let resolveApi!: (id: string) => void;
+    mockRegisterCoachForSession.mockImplementation(() => new Promise<string>(r => { resolveApi = r; }));
+    render(<ConfirmCoachRegistrationDialog {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
+    resolveApi('reg-123');
+  });
+
+  it('does not call onSuccess on error', async () => {
+    mockRegisterCoachForSession.mockRejectedValue(new Error('already_taken'));
+    const onSuccess = vi.fn();
+    render(<ConfirmCoachRegistrationDialog {...defaultProps} onSuccess={onSuccess} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    await waitFor(() => expect(mockRegisterCoachForSession).toHaveBeenCalled());
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
 });
+

--- a/web/src/features/coach/index.ts
+++ b/web/src/features/coach/index.ts
@@ -6,4 +6,4 @@ export { CoachLoginDialog } from './components/CoachLoginDialog';
 export { SessionCard } from './components/SessionCard';
 export { ConfirmCoachRegistrationDialog } from './components/ConfirmCoachRegistrationDialog';
 export { ConfirmRemoveCoachDialog } from './components/ConfirmRemoveCoachDialog';
-export type { CoachLoginDialogProps, CoachData, SessionItem } from './types';
+export type { CoachLoginDialogProps, CoachData, SessionItem, RegisterCoachForSessionPayload } from './types';

--- a/web/src/features/coach/types.ts
+++ b/web/src/features/coach/types.ts
@@ -46,6 +46,22 @@ export interface SessionItem {
   is_free_sparring: boolean;
 }
 
+/**
+ * Payload for registering a coach for a specific session.
+ * @see skills/SKILL.wire-react-to-gas.md
+ */
+export interface RegisterCoachForSessionPayload {
+  firstname: string;
+  lastname: string;
+  session_type: string;
+  /** Date in 'YYYY-MM-DD' format */
+  date: string;
+  /** Start time 'HH:MM' — only for free/sparring sessions */
+  start_time?: string;
+  /** End time 'HH:MM' — only for free/sparring sessions */
+  end_time?: string;
+}
+
 /** Props for the CoachLoginDialog component. */
 export interface CoachLoginDialogProps {
   /** Whether the dialog is visible. */

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -58,5 +58,16 @@
   "coachQuickRegistration.confirmRemoveMessage": "Remove from this session?",
   "coachQuickRegistration.confirm": "Confirm",
   "coachQuickRegistration.cancel": "Cancel",
-  "coachQuickRegistration.coach": "Coach: {{alias}}"
+  "coachQuickRegistration.coach": "Coach: {{alias}}",
+  "coachQuickRegistration.confirmRegisterQuestion": "Do you register as coach for this session?",
+  "coachQuickRegistration.sessionTypeLabel": "Session",
+  "coachQuickRegistration.sessionDateLabel": "Date",
+  "coachQuickRegistration.sessionTimeLabel": "Time",
+  "coachQuickRegistration.coachNameLabel": "Coach",
+  "coachQuickRegistration.registrationOngoing": "Registration ongoing. Please wait.",
+  "coachQuickRegistration.registrationSuccess": "Registration successful!",
+  "coachQuickRegistration.registrationFailed": "Registration failed. Please try again.",
+  "coachQuickRegistration.alreadyTaken": "Session already has a registered coach. Refresh page.",
+  "coachQuickRegistration.unknownCoach": "Unknown coach. Contact system administrator.",
+  "coachQuickRegistration.registrationCancelled": "Registration cancelled."
 }

--- a/web/src/locales/fi.json
+++ b/web/src/locales/fi.json
@@ -58,5 +58,16 @@
   "coachQuickRegistration.confirmRemoveMessage": "Poistua tältä harjoitukselta?",
   "coachQuickRegistration.confirm": "Vahvista",
   "coachQuickRegistration.cancel": "Peruuta",
-  "coachQuickRegistration.coach": "Valmentaja: {{alias}}"
+  "coachQuickRegistration.coach": "Valmentaja: {{alias}}",
+  "coachQuickRegistration.confirmRegisterQuestion": "Ilmoittaudutko valmentajaksi tälle harjoitukselle?",
+  "coachQuickRegistration.sessionTypeLabel": "Harjoitus",
+  "coachQuickRegistration.sessionDateLabel": "Päivämäärä",
+  "coachQuickRegistration.sessionTimeLabel": "Aika",
+  "coachQuickRegistration.coachNameLabel": "Valmentaja",
+  "coachQuickRegistration.registrationOngoing": "Ilmoittautuminen käynnissä. Odota.",
+  "coachQuickRegistration.registrationSuccess": "Ilmoittautuminen onnistui!",
+  "coachQuickRegistration.registrationFailed": "Ilmoittautuminen epäonnistui. Yritä uudelleen.",
+  "coachQuickRegistration.alreadyTaken": "Harjoituksella on jo ilmoittautunut valmentaja. Päivitä sivu.",
+  "coachQuickRegistration.unknownCoach": "Tuntematon valmentaja. Ota yhteyttä järjestelmänvalvojaan.",
+  "coachQuickRegistration.registrationCancelled": "Ilmoittautuminen peruutettu."
 }

--- a/web/src/pages/Coach/CoachPage.tsx
+++ b/web/src/pages/Coach/CoachPage.tsx
@@ -7,12 +7,14 @@
 /**
  * @description Coach Quick Registration Page — shown after coach authenticates via PIN or password.
  *   Fetches a 21-day window of session data from the GAS backend and displays session cards
- *   grouped by date. Coaches can click Register or Remove to trigger dummy confirmation dialogs.
+ *   grouped by date. Coaches can click Register to open a confirmation dialog that sends a
+ *   real registration to the backend (OQM-0008), or Remove to trigger a removal confirmation.
  *   Uses MUI for accessible and consistent UI.
  *   @see skills/SKILL.wire-react-to-gas.md
  */
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
@@ -90,6 +92,33 @@ export function CoachPage({ onBack, coachData }: CoachPageProps) {
     setConfirmRemoveOpen(true);
   }
 
+  function handleRegisterSuccess(registrationId: string) {
+    setConfirmRegisterOpen(false);
+    if (selectedSession && coachData) {
+      const coachName = coachData.alias || `${coachData.firstname} ${coachData.lastname}`;
+      setSessions(prev =>
+        prev.map(s =>
+          s.id === selectedSession.id
+            ? {
+                ...s,
+                coach_firstname: coachData.firstname,
+                coach_lastname: coachData.lastname,
+                coach_alias: coachName,
+                registration_id: registrationId,
+              }
+            : s
+        )
+      );
+    }
+    setSelectedSession(null);
+  }
+
+  function handleRegisterCancel() {
+    setConfirmRegisterOpen(false);
+    setSelectedSession(null);
+    toast(t('coachQuickRegistration.registrationCancelled'));
+  }
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh', p: 2 }}>
       <LoadingOverlay visible={loading} />
@@ -144,8 +173,10 @@ export function CoachPage({ onBack, coachData }: CoachPageProps) {
 
       <ConfirmCoachRegistrationDialog
         open={confirmRegisterOpen}
-        onConfirm={() => { setConfirmRegisterOpen(false); setSelectedSession(null); }}
-        onCancel={() => { setConfirmRegisterOpen(false); setSelectedSession(null); }}
+        session={selectedSession}
+        coachData={coachData}
+        onSuccess={handleRegisterSuccess}
+        onCancel={handleRegisterCancel}
       />
 
       <ConfirmRemoveCoachDialog

--- a/web/src/pages/Coach/__tests__/CoachPage.test.tsx
+++ b/web/src/pages/Coach/__tests__/CoachPage.test.tsx
@@ -21,9 +21,16 @@ vi.mock('../../../features/coach/api/coach.api', () => ({
   getCoachSessions: vi.fn(),
 }));
 
+vi.mock('react-hot-toast', () => ({
+  default: vi.fn(),
+  toast: vi.fn(),
+}));
+
 import { getCoachSessions } from '../../../features/coach/api/coach.api';
+import toast from 'react-hot-toast';
 
 const mockGetCoachSessions = vi.mocked(getCoachSessions);
+const mockToast = vi.mocked(toast);
 
 const mockSession: SessionItem = {
   id: 'ws-1_2026-03-09',
@@ -121,5 +128,26 @@ describe('CoachPage', () => {
     await waitFor(() => screen.getByRole('button', { name: 'Remove' }));
     await userEvent.click(screen.getByRole('button', { name: 'Remove' }));
     expect(screen.getByText('Confirm Removal')).toBeInTheDocument();
+  });
+
+  it('passes selected session and coachData to ConfirmCoachRegistrationDialog', async () => {
+    const coachData = { id: '1', firstname: 'John', lastname: 'Doe', alias: 'JD', pin: '1234', created_at: '', last_activity: '' };
+    mockGetCoachSessions.mockResolvedValue([mockSession]);
+    render(<CoachPage onBack={vi.fn()} coachData={coachData} />);
+    await waitFor(() => screen.getByRole('button', { name: 'Register' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Register' }));
+    // Dialog should open and show confirmation title
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Confirm Registration' })).toBeInTheDocument();
+  });
+
+  it('dismisses dialog and shows cancellation toast when cancel is clicked', async () => {
+    mockGetCoachSessions.mockResolvedValue([mockSession]);
+    render(<CoachPage onBack={vi.fn()} />);
+    await waitFor(() => screen.getByRole('button', { name: 'Register' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Register' }));
+    const cancelBtn = screen.getByRole('button', { name: 'Cancel' });
+    await userEvent.click(cancelBtn);
+    await waitFor(() => expect(mockToast).toHaveBeenCalledWith('Registration cancelled.'));
   });
 });


### PR DESCRIPTION
- Add registerCoachForSession GAS route to Code.gs
  - Validates coach exists in coach_login sheet
  - Checks session isn't already taken (already_taken error)
  - Returns unknown_coach if coach not found
  - Appends row to coach_registrations sheet on success
- Add RegisterCoachForSessionPayload type to types.ts
- Add registerCoachForSession API function to coach.api.ts
- Upgrade ConfirmCoachRegistrationDialog from dummy placeholder to real impl:
  - Displays session type, date, time, coach name
  - Calls registerCoachForSession on confirm with loading overlay
  - Shows toast feedback (ongoing/success/errors)
  - Calls onSuccess(registrationId) or onCancel accordingly
- Update CoachPage to wire real dialog:
  - Pass session and coachData to dialog
  - On success: update session state to show registered coach (green card)
  - On cancel: fire 'Registration cancelled.' toast
- Add i18n keys (en/fi) for all new messages and dialog labels
- Update SKILL.wire-react-to-gas.md with registerCoachForSession contract
- TDD: wrote failing tests first, then implemented to pass them

Closes #16

## Summary
- Linked issue: #

## Checklist
- [ ] Tests added/updated and passing
- [ ] No secrets committed
- [ ] API contract adhered to
- [ ] Updated docs/skills if schema or flows changed
