### PR TITLE
feat: OQM-0009 implement remove coach from session (#18)

### DIFF
--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -2,3 +2,4 @@
 - Use CLASP for local dev & deployments (`clasp login`, `clasp push`, `clasp version`, `clasp deploy`).
 - Web app must implement `doGet(e)` and/or `doPost(e)` and respond with JSON via `ContentService`.
 - Store secrets/tokens in Script Properties; never hardcode.
+- All operations that add/update/delete data must be atomic and handle concurrency (e.g. using LockService.getScriptLock(), LockService.waitLock() and Lock.releaseLock()).

--- a/gas/Code.gs
+++ b/gas/Code.gs
@@ -8,6 +8,7 @@
  *  - POST { route: "registerCoachPin", payload: { firstname, lastname, alias, pin } } — register a new coach PIN code (OQM-0003)
  *  - POST { route: "verifyCoachPin", payload: { pin } } — verify a coach PIN against coach_login sheet (OQM-0004)
  *  - POST { route: "registerCoachForSession", payload: { firstname, lastname, session_type, date, start_time?, end_time? } } — register coach for a session (OQM-0008)
+ *  - POST { route: "removeCoachFromSession", payload: { firstname, lastname, session_type, date } } — remove coach from a session (OQM-0009)
  */
 
 const SHEET_ID = PropertiesService.getScriptProperties().getProperty('SHEET_ID');
@@ -72,6 +73,19 @@ function doPost(e) {
       }
       if (result.unknownCoach) {
         return json_({ ok: false, error: 'unknown_coach' });
+      }
+      return json_({ ok: true, data: { id: result.id } });
+    }
+    if (route === 'removeCoachFromSession') {
+      const result = removeCoachFromSession_(payload);
+      if (result.concurrentOperation) {
+        return json_({ ok: false, error: 'concurrent_operation' });
+      }
+      if (result.registrationNotFound) {
+        return json_({ ok: false, error: 'registration_not_found' });
+      }
+      if (result.sessionAvailable) {
+        return json_({ ok: false, error: 'session_available' });
       }
       return json_({ ok: true, data: { id: result.id } });
     }
@@ -588,6 +602,80 @@ function getCoachSessions_() {
   logToSheet(`getCoachSessions_() - returned sessions: ` + JSON.stringify(sessions));
   
   return sessions;
+}
+
+/**
+ * Remove a coach from a specific session (OQM-0009).
+ * Acquires a script lock to prevent concurrent operations.
+ * Identifies the registration row by matching firstname, lastname, session_type, and date where realized=true.
+ * Updates realized to false and updated_at to the current timestamp.
+ * Returns { concurrentOperation: true } if the lock cannot be acquired.
+ * Returns { registrationNotFound: true } if no matching realized=true row exists.
+ * Returns { sessionAvailable: true } if the identified row has realized=false.
+ * Returns { id } of the updated row on success.
+ * Schema: id, first_name, last_name, session_type, date, realized, start_time, end_time, created_at, updated_at (cols A–J)
+ * See SKILL.sheet-schema.md for full schema definition.
+ * See SKILL.wire-react-to-gas.md for API contract (OQM-0009).
+ */
+function removeCoachFromSession_(payload) {
+  if (!payload || !payload.firstname || !payload.lastname || !payload.session_type || !payload.date) {
+    throw new Error('Missing required fields: firstname, lastname, session_type, date');
+  }
+
+  const lock = LockService.getScriptLock();
+  const acquired = lock.tryLock(5000);
+  if (!acquired) {
+    return { concurrentOperation: true };
+  }
+
+  try {
+    const tz = Session.getScriptTimeZone();
+    const sessionTypeUpper = payload.session_type.toUpperCase();
+    const sheet = getSheetByName('coach_registrations');
+    if (!sheet) throw new Error('Sheet not found: coach_registrations');
+
+    const data = sheet.getDataRange().getValues();
+    // data[0] is the header row; data starts at index 1 for actual rows
+    let matchRowIndex = -1;
+
+    for (let i = 1; i < data.length; i++) {
+      const row = data[i];
+      const rowFirstname = String(row[1] || '').trim();
+      const rowLastname = String(row[2] || '').trim();
+      const rowSessionType = String(row[3] || '').toUpperCase();
+      const rowDate = timeToStr(row[4], tz, 'yyyy-MM-dd');
+      const rowRealized = row.length >= 6 ? getBooleanValue(row[5]) : true;
+
+      if (
+        rowFirstname.toLowerCase() === payload.firstname.trim().toLowerCase() &&
+        rowLastname.toLowerCase() === payload.lastname.trim().toLowerCase() &&
+        rowSessionType === sessionTypeUpper &&
+        rowDate === payload.date
+      ) {
+        if (!rowRealized) {
+          return { sessionAvailable: true };
+        }
+        matchRowIndex = i;
+        break;
+      }
+    }
+
+    if (matchRowIndex === -1) {
+      return { registrationNotFound: true };
+    }
+
+    // Update realized=false and updated_at; sheet row is matchRowIndex + 1 (1-based)
+    const now = new Date().toISOString();
+    const sheetRow = matchRowIndex + 1;
+    sheet.getRange(sheetRow, 6).setValue(false);   // col F = realized
+    sheet.getRange(sheetRow, 10).setValue(now);    // col J = updated_at
+
+    const registrationId = String(data[matchRowIndex][0]);
+    logToSheet(`removeCoachFromSession_ - updated row ${sheetRow}, id: ${registrationId}`);
+    return { id: registrationId };
+  } finally {
+    lock.releaseLock();
+  }
 }
 
 // usage: 

--- a/skills/SKILL.wire-react-to-gas.md
+++ b/skills/SKILL.wire-react-to-gas.md
@@ -8,6 +8,7 @@
 - POST `{ route: "registerCoachPin", payload, token }` → register coach PIN (OQM-0003)
 - POST `{ route: "verifyCoachPin", payload, token }` → verify coach PIN, return coach data (OQM-0004)
 - POST `{ route: "registerCoachForSession", payload, token }` → register coach for a session (OQM-0008)
+- POST `{ route: "removeCoachFromSession", payload, token }` → remove coach from a session (OQM-0009)
 - Response JSON shape: `{ ok: true, data } | { ok: false, error }`
 
 ## Settings parameters used by the frontend
@@ -142,20 +143,81 @@ export async function verifyCoachPin(pin: string): Promise<CoachData> {
 }
 ```
 
+## removeCoachFromSession (OQM-0009)
+
+### Request
+```json
+{
+  "route": "removeCoachFromSession",
+  "payload": {
+    "firstname":    "string (required)",
+    "lastname":     "string (required)",
+    "session_type": "string (required)",
+    "date":         "string (required, YYYY-MM-DD)"
+  },
+  "token": "string"
+}
+```
+
+### Response (success)
+```json
+{ "ok": true, "data": { "id": "uuid" } }
+```
+
+### Response (error)
+```json
+{ "ok": false, "error": "concurrent_operation | registration_not_found | session_available" }
+```
+
+### Error cases
+| Error                    | Meaning                                                                                  |
+|--------------------------|------------------------------------------------------------------------------------------|
+| `concurrent_operation`   | Script lock could not be acquired — another operation is in progress                     |
+| `registration_not_found` | No realized=true row in `coach_registrations` for the given coach/session/date           |
+| `session_available`      | Matching row found but realized=false (session already has no coach)                     |
+| `Unauthorized`           | Invalid or missing API token                                                             |
+
+### Frontend API function
+```ts
+/** Payload for removing a coach from a specific session. */
+type RemoveCoachFromSessionPayload = {
+  firstname: string;
+  lastname: string;
+  session_type: string;
+  /** Date in 'YYYY-MM-DD' format */
+  date: string;
+};
+
+/**
+ * Remove a coach from a specific session.
+ * Returns the updated registration id on success.
+ * Throws Error('concurrent_operation') if a concurrent script lock is held.
+ * Throws Error('registration_not_found') if no realized registration matches.
+ * Throws Error('session_available') if the matching registration is already realized=false.
+ * Throws other Errors on network/service failures.
+ */
+export async function removeCoachFromSession(payload: RemoveCoachFromSessionPayload): Promise<string> {
+  const base = import.meta.env.VITE_GAS_BASE_URL as string;
+  const token = import.meta.env.VITE_API_TOKEN as string;
+  if (!base) throw new Error('VITE_GAS_BASE_URL is not configured');
+  const res = await fetch(base, {
+    method: 'POST',
+    redirect: 'follow',
+    headers: { 'Content-Type': 'text/plain;charset=utf-8' },
+    body: JSON.stringify({ route: 'removeCoachFromSession', payload, token }),
+  });
+  const json = await res.json();
+  if (!json.ok) throw new Error(json.error || 'Removal failed');
+  return json.data.id as string;
+}
+```
+
 ## Frontend fetch patterns
 ```ts
 const base = import.meta.env.VITE_GAS_BASE_URL;
 const token = import.meta.env.VITE_API_TOKEN;
 
 /** Shape of a single row returned from the `settings` sheet. */
-type Setting = {
-  id: string;
-  parameter: string;
-  value: string;
-  created_at: string;
-  updated_at: string;
-  purpose: string;
-};
 
 /** Fetch all settings rows (QCM-0001 — fetched on application startup). */
 export async function getSettings(): Promise<Setting[]> {

--- a/user_stories/coach/features/OQM-0009-remove-coach-from-a-session/OQM-0009-remove-coach-from-a-session.md
+++ b/user_stories/coach/features/OQM-0009-remove-coach-from-a-session/OQM-0009-remove-coach-from-a-session.md
@@ -1,0 +1,84 @@
+**Title:** 
+Remove a coach from a session
+
+**Description:**  
+Enable a logged-in coach to remove coach from a session via the Coach Page. Removal is confirmed through a Confirm Remove Coach Dialog and the result is communicated to the user.
+
+**User Story:**  
+As a coach, I want to remove a registered coach from the session so that the session is again available for registration.
+
+**Preconditions:**  
+- User is logged in to Coach Page using PIN code or password
+- at least one session card with registered coach are available
+
+**Operation Flow:**  
+1. User clicks "Remove" button on a Session card
+2. Confirmation dialog appears
+3. User clicks "Confirm" → removal of registration sent to backend, result shown
+4. User clicks "Cancel" → dialog closes, cancellation toast shown
+
+**Dialog/Page Content:**
+- The ConfirmCoachRegistrationDialog displays:
+    - Confirmation text: "Remove a coach from this session?"
+    - Notification text: "Trainees may have registered to the session. Make sure they are informed about the cancellation via proper channels as soon as possible or that a new coach is registered for the session."
+    - Session information 
+        - session type
+        - date
+        - time
+    - Coach name or identifier
+    - Buttons: Confirm, Cancel
+
+**Data Handling:**
+1. GAS function locks the script or returns with error code 'concurrent_operation'
+2. GAS function first checks that there is a registered coach for the session from `coach_registration` sheet
+    - Identifying of the row is made by matching the coach first and lastname, date and session_type. The realized column value must be true
+    - if matching row is not found then return with error code `registration_not_found`
+    - if matching row is found but the realized column value is false then return with error code `session_available`
+3. Gas function updates the row
+    - realized
+        - boolean, value set to false
+    - updated_at
+        - current date and time in ISO 8601 format
+4. Returns id of the updated row or an error if operation fails
+5. Finally release the script lock
+
+**User Feedback:**
+Messages shown to the user:
+- Toast message: "Registration removal ongoing. Please wait." when registration removal operation starts
+- Success: "Registration removed successfully!"
+- Error: "Registration removal failed. Please try again."
+- concurrent_request error: "Concurrent operation ongoing. Refresh page before trying again."
+- session_available error: "Session already without registered coach. Refresh page."
+- registration_not_found error: "Registration not found. Refresh page."
+- Cancel: "Registration removal cancelled."
+- When registration removal has been succesful the Session Card's
+    - background color changes to orange
+    - button changes to "Register" button
+    - Coach name is removed from the Session Card
+- If session_type of the removed registration was 'free/sparring' then the Session card's button is disabled
+
+**Test Cases:**  
+- Coach can successfully remove registration for only one session at the time
+- Coach can remove registertration from another session after cancelling before confirmation
+- Coach sees notifications about the progress of the operation as well as Session Card changes when succesfully removed registration from a session
+- Coach receives error message if removal of registration fails 
+- Coach can cancel removal of registration before confirmation and sees cancellation notification
+- Concurrent operation ongoing
+
+**Acceptance Criteria:**  
+- Clicking "Remove" on a session card opens a confirmation dialog
+- Registration data must be validated before sending
+- Confirming registration removal sends data to backend (GAS API) and updates `coach_registrations` sheet  
+- User receives a success or failure message after registration removal attempt  
+- Cancelling registration removal closes the dialog and shows a cancellation toast
+- There is no limitations to how many sessions the user can remove registration but only one registration removal at a time
+- There is no limitations to how many session registration removals the user can cancel before confirmation
+- Concurrent operations not allowed
+
+**Linked Files/Branches:**  
+- [CoachPage.tsx](web/src/pages/Coach/CoachPage.tsx)
+- [SessionCard.tsx](web/src/features/coach/components/SessionCard.tsx)
+- [ConfirmRemoveCoachDialog.tsx](web/src/features/coach/components/ConfirmRemoveCoachDialog.tsx)
+- [coach_registrations sheet schema](skills/SKILL.sheet-schema.md)  
+- GAS API implementation ([Code.gs](gas/Code.gs))
+- [SKILL.wire-react-to-gas.md](skills/SKILL.wire-react-to-gas.md)

--- a/user_stories/coach/features/OQM-0009-remove-coach-from-a-session/prompt.md
+++ b/user_stories/coach/features/OQM-0009-remove-coach-from-a-session/prompt.md
@@ -1,0 +1,5 @@
+Implement the feature described in GitHub issue #18:
+- Follow [SKILL.wire-react-to-gas.md](http://_vscodecontentref_/0) for API contract
+- Use [SKILL.sheet-schema.md](http://_vscodecontentref_/1) for data structure
+- Apply all relevant instructions from [copilot-instructions.md](http://_vscodecontentref_/2) and [frontend.instructions.md](http://_vscodecontentref_/3) and [backend.instructions.md](http://_vscodecontentref_/4)
+- Use TDD and update documentation as required

--- a/web/src/features/coach/api/__tests__/coach.api.test.ts
+++ b/web/src/features/coach/api/__tests__/coach.api.test.ts
@@ -260,3 +260,69 @@ describe('registerCoachForSession', () => {
     ).rejects.toThrow('Unauthorized');
   });
 });
+
+import { removeCoachFromSession } from '../coach.api';
+
+describe('removeCoachFromSession', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_GAS_BASE_URL', BASE);
+    vi.stubEnv('VITE_API_TOKEN', TOKEN);
+    mockFetch.mockReset();
+  });
+
+  it('throws when VITE_GAS_BASE_URL is not configured', async () => {
+    vi.stubEnv('VITE_GAS_BASE_URL', '');
+    await expect(
+      removeCoachFromSession({ firstname: 'John', lastname: 'Doe', session_type: 'Kickboxing', date: '2026-03-09' })
+    ).rejects.toThrow('VITE_GAS_BASE_URL is not configured');
+  });
+
+  it('sends a POST request with correct shape', async () => {
+    mockFetch.mockResolvedValue({ json: async () => ({ ok: true, data: { id: 'reg-1' } }) });
+    const payload = { firstname: 'John', lastname: 'Doe', session_type: 'Kickboxing', date: '2026-03-09' };
+    await removeCoachFromSession(payload);
+    expect(mockFetch).toHaveBeenCalledWith(
+      BASE,
+      expect.objectContaining({
+        method: 'POST',
+        redirect: 'follow',
+        headers: { 'Content-Type': 'text/plain;charset=utf-8' },
+        body: JSON.stringify({ route: 'removeCoachFromSession', payload, token: TOKEN }),
+      })
+    );
+  });
+
+  it('returns registration id when backend returns ok: true', async () => {
+    mockFetch.mockResolvedValue({ json: async () => ({ ok: true, data: { id: 'reg-1' } }) });
+    const result = await removeCoachFromSession({ firstname: 'John', lastname: 'Doe', session_type: 'Kickboxing', date: '2026-03-09' });
+    expect(result).toBe('reg-1');
+  });
+
+  it('throws "concurrent_operation" when backend returns that error', async () => {
+    mockFetch.mockResolvedValue({ json: async () => ({ ok: false, error: 'concurrent_operation' }) });
+    await expect(
+      removeCoachFromSession({ firstname: 'John', lastname: 'Doe', session_type: 'Kickboxing', date: '2026-03-09' })
+    ).rejects.toThrow('concurrent_operation');
+  });
+
+  it('throws "registration_not_found" when backend returns that error', async () => {
+    mockFetch.mockResolvedValue({ json: async () => ({ ok: false, error: 'registration_not_found' }) });
+    await expect(
+      removeCoachFromSession({ firstname: 'John', lastname: 'Doe', session_type: 'Kickboxing', date: '2026-03-09' })
+    ).rejects.toThrow('registration_not_found');
+  });
+
+  it('throws "session_available" when backend returns that error', async () => {
+    mockFetch.mockResolvedValue({ json: async () => ({ ok: false, error: 'session_available' }) });
+    await expect(
+      removeCoachFromSession({ firstname: 'John', lastname: 'Doe', session_type: 'Kickboxing', date: '2026-03-09' })
+    ).rejects.toThrow('session_available');
+  });
+
+  it('throws with backend error message on other errors', async () => {
+    mockFetch.mockResolvedValue({ json: async () => ({ ok: false, error: 'Unauthorized' }) });
+    await expect(
+      removeCoachFromSession({ firstname: 'John', lastname: 'Doe', session_type: 'Kickboxing', date: '2026-03-09' })
+    ).rejects.toThrow('Unauthorized');
+  });
+});

--- a/web/src/features/coach/api/coach.api.ts
+++ b/web/src/features/coach/api/coach.api.ts
@@ -11,7 +11,7 @@
  *   @see skills/SKILL.wire-react-to-gas.md
  */
 import type { RegisterPinData } from '../../../shared/components/RegisterPinDialog/RegisterPinDialog';
-import type { CoachData, SessionItem, RegisterCoachForSessionPayload } from '../types';
+import type { CoachData, SessionItem, RegisterCoachForSessionPayload, RemoveCoachFromSessionPayload } from '../types';
 
 /**
  * Register a new coach PIN code by posting to the GAS backend.
@@ -94,5 +94,30 @@ export async function registerCoachForSession(payload: RegisterCoachForSessionPa
   });
   const json = await res.json();
   if (!json.ok) throw new Error(json.error || 'Registration failed');
+  return json.data.id as string;
+}
+
+/**
+ * Remove a coach from a specific session (OQM-0009).
+ * POST { route: "removeCoachFromSession", payload: RemoveCoachFromSessionPayload, token }
+ * Returns the updated registration id on success.
+ * Throws Error('concurrent_operation') if a concurrent script lock is held.
+ * Throws Error('registration_not_found') if no realized registration matches.
+ * Throws Error('session_available') if the matching registration is already realized=false.
+ * Throws other Errors for network/service failures.
+ * @see skills/SKILL.wire-react-to-gas.md
+ */
+export async function removeCoachFromSession(payload: RemoveCoachFromSessionPayload): Promise<string> {
+  const base = import.meta.env.VITE_GAS_BASE_URL as string;
+  const token = import.meta.env.VITE_API_TOKEN as string;
+  if (!base) throw new Error('VITE_GAS_BASE_URL is not configured');
+  const res = await fetch(base, {
+    method: 'POST',
+    redirect: 'follow',
+    headers: { 'Content-Type': 'text/plain;charset=utf-8' },
+    body: JSON.stringify({ route: 'removeCoachFromSession', payload, token }),
+  });
+  const json = await res.json();
+  if (!json.ok) throw new Error(json.error || 'Removal failed');
   return json.data.id as string;
 }

--- a/web/src/features/coach/components/ConfirmRemoveCoachDialog.tsx
+++ b/web/src/features/coach/components/ConfirmRemoveCoachDialog.tsx
@@ -5,46 +5,127 @@
  */
 
 /**
- * @description Dummy confirmation dialog shown when the coach clicks 'Remove' on a session card.
- *   No backend call is made — this is a placeholder dialog (OQM-0007).
+ * @description Confirmation dialog shown when a coach clicks 'Remove' on a session card (OQM-0009).
+ *   Displays session details and coach name, calls the GAS backend to remove the coach registration,
+ *   shows loading state during the API call, and notifies the parent on success or cancellation.
  *   Uses MUI Dialog for accessible and consistent UI.
+ *   @see skills/SKILL.wire-react-to-gas.md
  */
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogActions from '@mui/material/DialogActions';
 import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import Alert from '@mui/material/Alert';
+import { LoadingOverlay } from '../../../shared/components/LoadingOverlay/LoadingOverlay';
+import { removeCoachFromSession } from '../api/coach.api';
+import type { SessionItem } from '../types';
 
 export interface ConfirmRemoveCoachDialogProps {
   open: boolean;
-  onConfirm: () => void;
+  /** The session the coach wants to be removed from. */
+  session: SessionItem | null;
+  /** Called with the updated registration id after a successful removal. */
+  onSuccess: (registrationId: string) => void;
+  /** Called when the user clicks Cancel. */
   onCancel: () => void;
 }
 
-/** Dummy modal asking the coach to confirm removal from a session. */
+/** Format 'YYYY-MM-DD' as 'DD.MM.YYYY' for display. */
+function formatDate(dateStr: string): string {
+  const [year, month, day] = dateStr.split('-');
+  return `${day}.${month}.${year}`;
+}
+
+/** Modal confirming coach removal from a session — calls the GAS backend on confirm. */
 export function ConfirmRemoveCoachDialog({
   open,
-  onConfirm,
+  session,
+  onSuccess,
   onCancel,
 }: ConfirmRemoveCoachDialogProps) {
   const { t } = useTranslation();
+  const [loading, setLoading] = useState(false);
+
+  async function handleConfirm() {
+    if (!session || loading) return;
+    setLoading(true);
+    toast(t('coachQuickRegistration.removalOngoing'));
+    try {
+      const registrationId = await removeCoachFromSession({
+        firstname: session.coach_firstname,
+        lastname: session.coach_lastname,
+        session_type: session.session_type,
+        date: session.date,
+      });
+      toast.success(t('coachQuickRegistration.removalSuccess'));
+      onSuccess(registrationId);
+    } catch (err) {
+      const code = err instanceof Error ? err.message : '';
+      if (code === 'concurrent_operation') {
+        toast.error(t('coachQuickRegistration.concurrentOperation'));
+      } else if (code === 'session_available') {
+        toast.error(t('coachQuickRegistration.sessionAvailable'));
+      } else if (code === 'registration_not_found') {
+        toast.error(t('coachQuickRegistration.registrationNotFound'));
+      } else {
+        toast.error(t('coachQuickRegistration.removalFailed'));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const coachName = session
+    ? (session.coach_alias || `${session.coach_firstname} ${session.coach_lastname}`.trim())
+    : '';
 
   return (
     <Dialog open={open} onClose={onCancel} aria-labelledby="confirm-remove-title">
+      <LoadingOverlay visible={loading} />
       <DialogTitle id="confirm-remove-title">
         {t('coachQuickRegistration.confirmRemoveTitle')}
       </DialogTitle>
       <DialogContent>
         <DialogContentText>
-          {t('coachQuickRegistration.confirmRemoveMessage')}
+          {t('coachQuickRegistration.confirmRemoveQuestion')}
         </DialogContentText>
+        <Alert severity="warning" sx={{ mt: 1, mb: 1 }}>
+          {t('coachQuickRegistration.confirmRemoveNotification')}
+        </Alert>
+        {session && (
+          <>
+            <Typography variant="body2" sx={{ mt: 1 }}>
+              <strong>{t('coachQuickRegistration.sessionTypeLabel')}:</strong>{' '}
+              {session.session_type_alias || session.session_type}
+            </Typography>
+            <Typography variant="body2">
+              <strong>{t('coachQuickRegistration.sessionDateLabel')}:</strong>{' '}
+              {formatDate(session.date)}
+            </Typography>
+            <Typography variant="body2">
+              <strong>{t('coachQuickRegistration.sessionTimeLabel')}:</strong>{' '}
+              {session.start_time} – {session.end_time}
+            </Typography>
+          </>
+        )}
+        {coachName && (
+          <Typography variant="body2">
+            <strong>{t('coachQuickRegistration.coachNameLabel')}:</strong>{' '}
+            {coachName}
+          </Typography>
+        )}
       </DialogContent>
       <DialogActions>
-        <Button onClick={onCancel}>{t('coachQuickRegistration.cancel')}</Button>
-        <Button onClick={onConfirm} variant="contained" color="error">
+        <Button onClick={onCancel} disabled={loading}>
+          {t('coachQuickRegistration.cancel')}
+        </Button>
+        <Button onClick={handleConfirm} variant="contained" color="error" disabled={loading || !session}>
           {t('coachQuickRegistration.confirm')}
         </Button>
       </DialogActions>

--- a/web/src/features/coach/components/SessionCard.tsx
+++ b/web/src/features/coach/components/SessionCard.tsx
@@ -41,6 +41,9 @@ export function SessionCard({ session, onRegister, onRemove, cardStyle }: Sessio
 
   const displayName = session.session_type_alias || session.session_type;
 
+  /** Register button is disabled for free/sparring sessions that have no coach assigned. */
+  const isRegisterDisabled = !hasCoach && session.is_free_sparring;
+
   return (
     <Card sx={{ backgroundColor, mb: 1, color: '#fff', border: `2px solid ${theme.palette.common.white}`, ...cardStyle }}>
       <Box sx={{ display: 'flex', flexDirection: 'row', height: '100%' }}>
@@ -77,6 +80,7 @@ export function SessionCard({ session, onRegister, onRemove, cardStyle }: Sessio
               variant="contained"
               color="primary"
               onClick={() => onRegister(session)}
+              disabled={isRegisterDisabled}
               sx={{ border: '1px solid #000' }}
             >
               {t('coachQuickRegistration.register')}

--- a/web/src/features/coach/components/__tests__/ConfirmRemoveCoachDialog.test.tsx
+++ b/web/src/features/coach/components/__tests__/ConfirmRemoveCoachDialog.test.tsx
@@ -5,24 +5,52 @@
  */
 
 /**
- * @description Tests for ConfirmRemoveCoachDialog — dummy confirmation dialog.
+ * @description Tests for ConfirmRemoveCoachDialog — real removal confirmation dialog (OQM-0009).
  *   Written before implementation (TDD).
  */
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import '../../../../lib/i18n';
 import { ConfirmRemoveCoachDialog } from '../ConfirmRemoveCoachDialog';
+import type { SessionItem } from '../../types';
+
+vi.mock('../../api/coach.api', () => ({
+  removeCoachFromSession: vi.fn(),
+}));
+
+import { removeCoachFromSession } from '../../api/coach.api';
+const mockRemoveCoachFromSession = vi.mocked(removeCoachFromSession);
+
+const mockSession: SessionItem = {
+  id: 'ws-1_2026-03-09',
+  session_type: 'Kickboxing',
+  session_type_alias: 'Nyrkkeilyharjoitus',
+  date: '2026-03-09',
+  start_time: '18:00',
+  end_time: '19:30',
+  location: 'Gym A',
+  coach_firstname: 'John',
+  coach_lastname: 'Doe',
+  coach_alias: 'JD',
+  registration_id: 'reg-1',
+  is_free_sparring: false,
+};
 
 const defaultProps = {
   open: true,
-  onConfirm: vi.fn(),
+  session: mockSession,
+  onSuccess: vi.fn(),
   onCancel: vi.fn(),
 };
 
 describe('ConfirmRemoveCoachDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('does not render when open=false', () => {
     render(<ConfirmRemoveCoachDialog {...defaultProps} open={false} />);
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
@@ -38,9 +66,34 @@ describe('ConfirmRemoveCoachDialog', () => {
     expect(screen.getByText('Confirm Removal')).toBeInTheDocument();
   });
 
-  it('renders confirmation message', () => {
+  it('renders confirmation question text', () => {
     render(<ConfirmRemoveCoachDialog {...defaultProps} />);
-    expect(screen.getByText('Remove from this session?')).toBeInTheDocument();
+    expect(screen.getByText('Remove a coach from this session?')).toBeInTheDocument();
+  });
+
+  it('renders notification about trainees', () => {
+    render(<ConfirmRemoveCoachDialog {...defaultProps} />);
+    expect(screen.getByText(/Trainees may have registered/)).toBeInTheDocument();
+  });
+
+  it('renders session type alias', () => {
+    render(<ConfirmRemoveCoachDialog {...defaultProps} />);
+    expect(screen.getByText(/Nyrkkeilyharjoitus/)).toBeInTheDocument();
+  });
+
+  it('renders session date', () => {
+    render(<ConfirmRemoveCoachDialog {...defaultProps} />);
+    expect(screen.getByText(/09\.03\.2026/)).toBeInTheDocument();
+  });
+
+  it('renders session time', () => {
+    render(<ConfirmRemoveCoachDialog {...defaultProps} />);
+    expect(screen.getByText(/18:00/)).toBeInTheDocument();
+  });
+
+  it('renders coach alias', () => {
+    render(<ConfirmRemoveCoachDialog {...defaultProps} />);
+    expect(screen.getByText(/JD/)).toBeInTheDocument();
   });
 
   it('renders Confirm button', () => {
@@ -53,17 +106,48 @@ describe('ConfirmRemoveCoachDialog', () => {
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
   });
 
-  it('calls onConfirm when Confirm is clicked', async () => {
-    const onConfirm = vi.fn();
-    render(<ConfirmRemoveCoachDialog {...defaultProps} onConfirm={onConfirm} />);
-    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
-    expect(onConfirm).toHaveBeenCalledOnce();
-  });
-
   it('calls onCancel when Cancel is clicked', async () => {
     const onCancel = vi.fn();
     render(<ConfirmRemoveCoachDialog {...defaultProps} onCancel={onCancel} />);
     await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('calls removeCoachFromSession with correct payload when Confirm is clicked', async () => {
+    mockRemoveCoachFromSession.mockResolvedValue('reg-1');
+    render(<ConfirmRemoveCoachDialog {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(mockRemoveCoachFromSession).toHaveBeenCalledWith({
+      firstname: 'John',
+      lastname: 'Doe',
+      session_type: 'Kickboxing',
+      date: '2026-03-09',
+    });
+  });
+
+  it('calls onSuccess with registrationId after successful removal', async () => {
+    mockRemoveCoachFromSession.mockResolvedValue('reg-1');
+    const onSuccess = vi.fn();
+    render(<ConfirmRemoveCoachDialog {...defaultProps} onSuccess={onSuccess} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledWith('reg-1'));
+  });
+
+  it('disables Confirm button during API call', async () => {
+    let resolveApi!: (id: string) => void;
+    mockRemoveCoachFromSession.mockImplementation(() => new Promise<string>(r => { resolveApi = r; }));
+    render(<ConfirmRemoveCoachDialog {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(screen.getByRole('button', { name: 'Confirm' })).toBeDisabled();
+    resolveApi('reg-1');
+  });
+
+  it('does not call onSuccess on error', async () => {
+    mockRemoveCoachFromSession.mockRejectedValue(new Error('registration_not_found'));
+    const onSuccess = vi.fn();
+    render(<ConfirmRemoveCoachDialog {...defaultProps} onSuccess={onSuccess} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    await waitFor(() => expect(mockRemoveCoachFromSession).toHaveBeenCalled());
+    expect(onSuccess).not.toHaveBeenCalled();
   });
 });

--- a/web/src/features/coach/components/__tests__/SessionCard.test.tsx
+++ b/web/src/features/coach/components/__tests__/SessionCard.test.tsx
@@ -105,4 +105,15 @@ describe('SessionCard', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Remove' }));
     expect(onRemove).toHaveBeenCalledWith(sessionWithCoach);
   });
+
+  it('disables Register button when no coach and session is free/sparring', () => {
+    const freeSparringSession: SessionItem = { ...baseSession, session_type: 'free/sparring', is_free_sparring: true };
+    renderCard(freeSparringSession);
+    expect(screen.getByRole('button', { name: 'Register' })).toBeDisabled();
+  });
+
+  it('enables Register button when no coach and session is not free/sparring', () => {
+    renderCard(baseSession);
+    expect(screen.getByRole('button', { name: 'Register' })).not.toBeDisabled();
+  });
 });

--- a/web/src/features/coach/types.ts
+++ b/web/src/features/coach/types.ts
@@ -62,6 +62,18 @@ export interface RegisterCoachForSessionPayload {
   end_time?: string;
 }
 
+/**
+ * Payload for removing a coach from a specific session (OQM-0009).
+ * @see skills/SKILL.wire-react-to-gas.md
+ */
+export interface RemoveCoachFromSessionPayload {
+  firstname: string;
+  lastname: string;
+  session_type: string;
+  /** Date in 'YYYY-MM-DD' format */
+  date: string;
+}
+
 /** Props for the CoachLoginDialog component. */
 export interface CoachLoginDialogProps {
   /** Whether the dialog is visible. */

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -69,5 +69,14 @@
   "coachQuickRegistration.registrationFailed": "Registration failed. Please try again.",
   "coachQuickRegistration.alreadyTaken": "Session already has a registered coach. Refresh page.",
   "coachQuickRegistration.unknownCoach": "Unknown coach. Contact system administrator.",
-  "coachQuickRegistration.registrationCancelled": "Registration cancelled."
+  "coachQuickRegistration.registrationCancelled": "Registration cancelled.",
+  "coachQuickRegistration.confirmRemoveQuestion": "Remove a coach from this session?",
+  "coachQuickRegistration.confirmRemoveNotification": "Trainees may have registered to the session. Make sure they are informed about the cancellation via proper channels as soon as possible or that a new coach is registered for the session.",
+  "coachQuickRegistration.removalOngoing": "Registration removal ongoing. Please wait.",
+  "coachQuickRegistration.removalSuccess": "Registration removed successfully!",
+  "coachQuickRegistration.removalFailed": "Registration removal failed. Please try again.",
+  "coachQuickRegistration.concurrentOperation": "Concurrent operation ongoing. Refresh page before trying again.",
+  "coachQuickRegistration.sessionAvailable": "Session already without registered coach. Refresh page.",
+  "coachQuickRegistration.registrationNotFound": "Registration not found. Refresh page.",
+  "coachQuickRegistration.removalCancelled": "Registration removal cancelled."
 }

--- a/web/src/locales/fi.json
+++ b/web/src/locales/fi.json
@@ -69,5 +69,14 @@
   "coachQuickRegistration.registrationFailed": "Ilmoittautuminen epäonnistui. Yritä uudelleen.",
   "coachQuickRegistration.alreadyTaken": "Harjoituksella on jo ilmoittautunut valmentaja. Päivitä sivu.",
   "coachQuickRegistration.unknownCoach": "Tuntematon valmentaja. Ota yhteyttä järjestelmänvalvojaan.",
-  "coachQuickRegistration.registrationCancelled": "Ilmoittautuminen peruutettu."
+  "coachQuickRegistration.registrationCancelled": "Ilmoittautuminen peruutettu.",
+  "coachQuickRegistration.confirmRemoveQuestion": "Poistetaanko valmentaja tältä harjoitukselta?",
+  "coachQuickRegistration.confirmRemoveNotification": "Harjoittelijat ovat saattaneet ilmoittautua harjoitukseen. Varmista, että heitä tiedotetaan peruutuksesta asianmukaisten kanavien kautta mahdollisimman pian tai että harjoitukselle rekisteröidään uusi valmentaja.",
+  "coachQuickRegistration.removalOngoing": "Ilmoittautumisen poistaminen käynnissä. Odota.",
+  "coachQuickRegistration.removalSuccess": "Ilmoittautuminen poistettu onnistuneesti!",
+  "coachQuickRegistration.removalFailed": "Ilmoittautumisen poistaminen epäonnistui. Yritä uudelleen.",
+  "coachQuickRegistration.concurrentOperation": "Samanaikainen operaatio käynnissä. Päivitä sivu ennen kuin yrität uudelleen.",
+  "coachQuickRegistration.sessionAvailable": "Harjoituksella ei ole rekisteröitynyttä valmentajaa. Päivitä sivu.",
+  "coachQuickRegistration.registrationNotFound": "Ilmoittautumista ei löydy. Päivitä sivu.",
+  "coachQuickRegistration.removalCancelled": "Ilmoittautumisen poistaminen peruutettu."
 }

--- a/web/src/pages/Coach/CoachPage.tsx
+++ b/web/src/pages/Coach/CoachPage.tsx
@@ -119,6 +119,26 @@ export function CoachPage({ onBack, coachData }: CoachPageProps) {
     toast(t('coachQuickRegistration.registrationCancelled'));
   }
 
+  function handleRemoveSuccess(_registrationId: string) {
+    setConfirmRemoveOpen(false);
+    if (selectedSession) {
+      setSessions(prev =>
+        prev.map(s =>
+          s.id === selectedSession.id
+            ? { ...s, coach_firstname: '', coach_lastname: '', coach_alias: '', registration_id: '' }
+            : s
+        )
+      );
+    }
+    setSelectedSession(null);
+  }
+
+  function handleRemoveCancel() {
+    setConfirmRemoveOpen(false);
+    setSelectedSession(null);
+    toast(t('coachQuickRegistration.removalCancelled'));
+  }
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh', p: 2 }}>
       <LoadingOverlay visible={loading} />
@@ -181,8 +201,9 @@ export function CoachPage({ onBack, coachData }: CoachPageProps) {
 
       <ConfirmRemoveCoachDialog
         open={confirmRemoveOpen}
-        onConfirm={() => { setConfirmRemoveOpen(false); setSelectedSession(null); }}
-        onCancel={() => { setConfirmRemoveOpen(false); setSelectedSession(null); }}
+        session={selectedSession}
+        onSuccess={handleRemoveSuccess}
+        onCancel={handleRemoveCancel}
       />
     </Box>
   );

--- a/web/src/pages/Coach/__tests__/CoachPage.test.tsx
+++ b/web/src/pages/Coach/__tests__/CoachPage.test.tsx
@@ -19,17 +19,23 @@ import type { SessionItem } from '../../../features/coach/types';
 
 vi.mock('../../../features/coach/api/coach.api', () => ({
   getCoachSessions: vi.fn(),
+  removeCoachFromSession: vi.fn(),
 }));
 
-vi.mock('react-hot-toast', () => ({
-  default: vi.fn(),
-  toast: vi.fn(),
-}));
+vi.mock('react-hot-toast', () => {
+  const toastFn = Object.assign(vi.fn(), {
+    success: vi.fn(),
+    error: vi.fn(),
+  });
+  return { default: toastFn };
+});
 
 import { getCoachSessions } from '../../../features/coach/api/coach.api';
+import { removeCoachFromSession } from '../../../features/coach/api/coach.api';
 import toast from 'react-hot-toast';
 
 const mockGetCoachSessions = vi.mocked(getCoachSessions);
+const mockRemoveCoachFromSession = vi.mocked(removeCoachFromSession);
 const mockToast = vi.mocked(toast);
 
 const mockSession: SessionItem = {
@@ -149,5 +155,27 @@ describe('CoachPage', () => {
     const cancelBtn = screen.getByRole('button', { name: 'Cancel' });
     await userEvent.click(cancelBtn);
     await waitFor(() => expect(mockToast).toHaveBeenCalledWith('Registration cancelled.'));
+  });
+
+  it('shows ConfirmRemoveCoachDialog dismisses on cancel with removal cancellation toast', async () => {
+    const sessionWithCoach = { ...mockSession, coach_alias: 'JD', coach_firstname: 'John', coach_lastname: 'Doe', registration_id: 'reg-1' };
+    mockGetCoachSessions.mockResolvedValue([sessionWithCoach]);
+    render(<CoachPage onBack={vi.fn()} />);
+    await waitFor(() => screen.getByRole('button', { name: 'Remove' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Remove' }));
+    const cancelBtn = screen.getByRole('button', { name: 'Cancel' });
+    await userEvent.click(cancelBtn);
+    await waitFor(() => expect(mockToast).toHaveBeenCalledWith('Registration removal cancelled.'));
+  });
+
+  it('updates session card to show Register button after successful removal', async () => {
+    const sessionWithCoach = { ...mockSession, coach_alias: 'JD', coach_firstname: 'John', coach_lastname: 'Doe', registration_id: 'reg-1' };
+    mockGetCoachSessions.mockResolvedValue([sessionWithCoach]);
+    mockRemoveCoachFromSession.mockResolvedValue('reg-1');
+    render(<CoachPage onBack={vi.fn()} />);
+    await waitFor(() => screen.getByRole('button', { name: 'Remove' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Remove' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Register' })).toBeInTheDocument());
   });
 });


### PR DESCRIPTION
- Add removeCoachFromSession GAS backend function with LockService concurrency guard
- Add removeCoachFromSession frontend API function (coach.api.ts)
- Implement ConfirmRemoveCoachDialog with full backend integration, session details, trainee notification, loading overlay and error handling
- Disable Register button for free/sparring sessions without a coach (SessionCard)
- Wire CoachPage removal flow: handleRemoveSuccess updates session state, handleRemoveCancel shows cancellation toast
- Add RemoveCoachFromSessionPayload type to types.ts
- Add translation keys for removal flow (en + fi): removalOngoing, removalSuccess, removalFailed, concurrentOperation, sessionAvailable, registrationNotFound, removalCancelled, confirmRemoveQuestion, confirmRemoveNotification
- Update SKILL.wire-react-to-gas.md with removeCoachFromSession API contract
- TDD: all 25 new tests pass (API, Dialog, SessionCard, CoachPage)

## Summary
- Linked issue: #18

## Checklist
- [x] Tests added/updated and passing
- [x] No secrets committed
- [x] API contract adhered to
- [x] Updated docs/skills if schema or flows changed
