### PR TITLE
feat: OQM-0010 Implement manual coach registration dialog and integrate PIN registration flow

### DIFF
--- a/skills/SKILL.wire-react-to-gas.md
+++ b/skills/SKILL.wire-react-to-gas.md
@@ -62,10 +62,11 @@ type RegisterPinData = {
 
 /**
  * Register a new coach PIN code.
+ * Returns the newly created CoachData on success (OQM-0010: used to pre-fill ConfirmCoachRegistrationDialog).
  * Throws Error('pin_reserved') if PIN is taken.
  * Throws other Errors on network/service failures.
  */
-export async function registerCoachPin(data: RegisterPinData): Promise<void> {
+export async function registerCoachPin(data: RegisterPinData): Promise<CoachData> {
   const base = import.meta.env.VITE_GAS_BASE_URL as string;
   const token = import.meta.env.VITE_API_TOKEN as string;
   if (!base) throw new Error('VITE_GAS_BASE_URL is not configured');
@@ -77,6 +78,7 @@ export async function registerCoachPin(data: RegisterPinData): Promise<void> {
   });
   const json = await res.json();
   if (!json.ok) throw new Error(json.error || 'Registration failed');
+  return json.data as CoachData;
 }
 ```
 

--- a/user_stories/coach/features/OQM-0010-register-coach-for-session-classic/OQM-0010-register-coach-for-session-classic.md
+++ b/user_stories/coach/features/OQM-0010-register-coach-for-session-classic/OQM-0010-register-coach-for-session-classic.md
@@ -1,0 +1,115 @@
+**Title:**
+Register Coach For a Session Using Classic Method
+
+**Description:**  
+Enable a coach logged-in using password to register for an available session via Coach Page. Registration is confirmed through a dialog and the result is communicated to the user.
+
+**User Story:**  
+As a coach, I want to register for a session when I have logged-in using password, so that my participation is recorded and confirmed.
+
+**Preconditions:**  
+- User is logged in to Coach Page using password
+- At least one Session card with no registered coach are available
+
+**Operation Flow:**  
+1. User clicks "Register" button on a Session card
+2. Manual Coach Registration Dialog opens
+    - User fills required information and clicks "Ok" → Confirm Coach Registration Dialog opens with coach and session info
+    - User clicks "Cancel" → dialog closes
+    - If user clicks "Register PIN code" link
+        - Register Pin Dialog opens
+        - if user has filled first name and last name fields, these transfer to dialog's fields
+        - If PIN code registration operation was succesfull
+            - Manual Coach Registration Dialog closes
+            - Confirm Coach Registration Dialog open with coach and session info
+3. In Confirm Coach Registration Dialog
+    - User clicks "Confirm" → registration data sent to backend, result shown
+    - User clicks "Cancel" → dialog closes, cancellation toast shown
+
+**Dialog/Page Content:**
+- Manual Coach Registration Dialog
+    - Title text: "Fill your information"
+    - Mui component: Stack
+        - MUI component: TextField
+            - id: "outlined-helpertext"
+            - label: "First name:"
+            - defaultValue: "Your first name"
+            - required
+        - MUI component: TextField
+            - id: "outlined-helpertext"
+            - label: "Last name:"
+            - defaultValue: "Your last name"
+            - required
+    - MUI component: Box
+        - Hint text: "With personal PIN code, you speed up and simplify your registration."
+        - MUI component: Link
+            - component="button"
+            - variant="body2"
+            - Text: "Register PIN code"
+    - MUI component: Box
+        - MUI component: ButtonGroup
+          - Button: "Confirm"
+          - Button: "Cancel"
+    - use theme where possible
+
+**Data Handling:**
+- See [SKILL.wire-react-to-gas.md](skills/SKILL.wire-react-to-gas.md) for
+    - PIN code registration data handling as described in `registerCoachPin (OQM-0003)` and `verifyCoachPin (OQM-0004)`
+    - Registration Coach For Session data handling as described in `registerCoachForSession (OQM-0008)`
+
+**User Feedback:**
+Messages shown to the user:
+- Toast message: "Registration ongoing. Please wait." when registration operation starts
+- Success: "Registration successful!"
+- Error: "Registration failed. Please try again."
+- already_taken error: "Session already has a registered coach. Refresh page."
+- unknown_coach error: "Unknown coach. Contact system administrator."
+- Cancel: "Registration cancelled."
+- When registration succesful the Session Card's
+    - background color changes to green
+    - button changes to "Remove" button
+    - Coach name is shown in the Session Card
+- also other appropriate messages inherited from features mentioned in `** Data Handling**` section that are missing here
+
+**Test Cases:**  
+- "OK" button of Manual Coach Registration Dialog is disabled as long as all required fields are filled
+- User clicks "Cancel" button of Manual Coach Registration Dialog at any point before clicking "OK" button
+    - dialog fields are cleared
+    - dialog closes
+    - coach is not registered to a session
+    - cancellation notification is shown to the user
+- User fills first and last name fields of Manual Coach Registration Dialog and clicks the link
+    - first and last names are transfered to opened Register Pin Dialog
+- User doesn not fill any fields of Manual Coach Registration Dialog and clicks the link
+    - Register Pin Dialog opened with empty fields
+- User clicks "Register" button of Register Pin Dialog
+    - Coach PIN code registration data sent to backend and the result is shown
+    - When PIN code is successfully registered: Register Pin Dialog and Manual Coach Registration Dialog closes and Confirm Coach Registration Dialog opens with coach and session info
+- [Define how the feature/bug will be tested.]
+
+**Acceptance Criteria:**  
+- Coach can register for a session via the Coach Page when logged in with a password.
+- "Register" button is visible only for sessions without a registered coach.
+- Manual Coach Registration Dialog opens when "Register" is clicked.
+- "OK" button in the dialog is disabled until all required fields are filled.
+- "Cancel" button closes the dialog, clears fields, and shows a cancellation notification.
+- "Register PIN code" link opens Register Pin Dialog; filled name fields transfer to the dialog.
+- Successful PIN registration closes Manual Coach Registration Dialog and opens Confirm Coach Registration Dialog.
+- Confirm Coach Registration Dialog displays correct coach and session info.
+- "Confirm" button sends registration to backend; user sees "Registration ongoing" toast.
+- On success, user sees "Registration successful" toast, Session Card updates (green background, "Remove" button, coach name shown).
+- On error, user sees appropriate error toast ("Registration failed", "Session already has a registered coach", "Unknown coach").
+- "Cancel" in Confirm dialog closes dialog and shows cancellation toast.
+- Data handling follows backend contract in [SKILL.wire-react-to-gas.md](skills/SKILL.wire-react-to-gas.md).
+
+**Linked Files/Branches:**  
+- [CoachPage.tsx](web/src/pages/Coach/CoachPage.tsx)
+- [ConfirmCoachRegistrationDialog.tsx](web/src/features/coach/components/ConfirmCoachRegistrationDialog.tsx)
+- [RegisterPinDialog.tsx](web/src/shared/components/RegisterPinDialog/RegisterPinDialog.tsx)
+- [SessionCard.tsx](web/src/features/coach/components/SessionCard.tsx)
+- [coach_registrations sheet schema](skills/SKILL.sheet-schema.md)  
+- GAS API implementation ([Code.gs](gas/Code.gs))
+- [SKILL.wire-react-to-gas.md](skills/SKILL.wire-react-to-gas.md)
+
+**Additional Context:**  
+- Refactor GAS functions `registerCoachPin_(payload)` and `registerCoachForSession_(payload)` to handle concurrency.

--- a/user_stories/coach/features/OQM-0010-register-coach-for-session-classic/prompt.md
+++ b/user_stories/coach/features/OQM-0010-register-coach-for-session-classic/prompt.md
@@ -1,0 +1,5 @@
+Implement the feature described in GitHub issue #20:
+- Follow [SKILL.wire-react-to-gas.md](http://_vscodecontentref_/0) for API contract
+- Use [SKILL.sheet-schema.md](http://_vscodecontentref_/1) for data structure
+- Apply all relevant instructions from [copilot-instructions.md](http://_vscodecontentref_/2) and [frontend.instructions.md](http://_vscodecontentref_/3) and [backend.instructions.md](http://_vscodecontentref_/4)
+- Use TDD and update documentation as required

--- a/web/src/features/coach/api/__tests__/coach.api.test.ts
+++ b/web/src/features/coach/api/__tests__/coach.api.test.ts
@@ -33,8 +33,9 @@ describe('registerCoachPin', () => {
   });
 
   it('sends a POST request with correct shape', async () => {
+    const coachData = { id: 'abc', firstname: 'John', lastname: 'Doe', alias: 'JD', pin: '1234', created_at: '2026-01-01T00:00:00Z', last_activity: '' };
     mockFetch.mockResolvedValue({
-      json: async () => ({ ok: true, data: {} }),
+      json: async () => ({ ok: true, data: coachData }),
     });
     await registerCoachPin({ firstname: 'John', lastname: 'Doe', alias: 'JD', pin: '1234' });
     expect(mockFetch).toHaveBeenCalledWith(
@@ -52,13 +53,14 @@ describe('registerCoachPin', () => {
     );
   });
 
-  it('resolves when backend returns ok: true', async () => {
+  it('returns CoachData when backend returns ok: true', async () => {
+    const coachData = { id: 'abc', firstname: 'John', lastname: 'Doe', alias: '', pin: '1234', created_at: '2026-01-01T00:00:00Z', last_activity: '' };
     mockFetch.mockResolvedValue({
-      json: async () => ({ ok: true, data: { id: 'abc' } }),
+      json: async () => ({ ok: true, data: coachData }),
     });
     await expect(
       registerCoachPin({ firstname: 'John', lastname: 'Doe', alias: '', pin: '1234' })
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual(coachData);
   });
 
   it('throws "pin_reserved" when backend returns error "pin_reserved"', async () => {

--- a/web/src/features/coach/api/coach.api.ts
+++ b/web/src/features/coach/api/coach.api.ts
@@ -16,10 +16,11 @@ import type { CoachData, SessionItem, RegisterCoachForSessionPayload, RemoveCoac
 /**
  * Register a new coach PIN code by posting to the GAS backend.
  * POST { route: "registerCoachPin", payload: RegisterPinData, token }
+ * Returns the newly created CoachData on success (OQM-0010: used to pre-fill ConfirmCoachRegistrationDialog).
  * Throws Error('pin_reserved') if the PIN already exists in coach_login or trainee_login.
  * Throws other Errors for network/service failures.
  */
-export async function registerCoachPin(data: RegisterPinData): Promise<void> {
+export async function registerCoachPin(data: RegisterPinData): Promise<CoachData> {
   const base = import.meta.env.VITE_GAS_BASE_URL as string;
   const token = import.meta.env.VITE_API_TOKEN as string;
   if (!base) throw new Error('VITE_GAS_BASE_URL is not configured');
@@ -31,6 +32,7 @@ export async function registerCoachPin(data: RegisterPinData): Promise<void> {
   });
   const json = await res.json();
   if (!json.ok) throw new Error(json.error || 'Registration failed');
+  return json.data as CoachData;
 }
 
 /**

--- a/web/src/features/coach/components/ManualCoachRegistrationDialog.tsx
+++ b/web/src/features/coach/components/ManualCoachRegistrationDialog.tsx
@@ -1,0 +1,235 @@
+/**
+ * @copyright 2026 Jouni Sipola by OQM. All rights reserved.
+ * Permission granted for personal/internal use only. Commercial
+ * use prohibited except by copyright holder. See LICENSE for details.
+ */
+
+/**
+ * @description Dialog shown when a password-authenticated coach clicks "Register" on a session card (OQM-0010).
+ *   Collects first name and last name for coaches without a PIN code.
+ *   Also supports opening RegisterPinDialog to register a PIN directly from this dialog;
+ *   pre-fills name fields when transferring to RegisterPinDialog.
+ *   After PIN registration, closes and opens ConfirmCoachRegistrationDialog with full CoachData.
+ *   @see skills/SKILL.wire-react-to-gas.md
+ */
+import React, { useEffect, useRef, useState } from 'react';
+import { useTheme } from '@mui/material/styles';
+import { useTranslation } from 'react-i18next';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
+import TextField from '@mui/material/TextField';
+import Button from '@mui/material/Button';
+import ButtonGroup from '@mui/material/ButtonGroup';
+import Box from '@mui/material/Box';
+import Link from '@mui/material/Link';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { RegisterPinDialog } from '../../../shared/components/RegisterPinDialog/RegisterPinDialog';
+import type { RegisterPinData } from '../../../shared/components/RegisterPinDialog/RegisterPinDialog';
+import { registerCoachPin } from '../api/coach.api';
+import type { CoachData } from '../types';
+
+/** Allows letters (including Nordic), spaces and hyphens between letter groups. */
+const NAME_PATTERN = /^[A-Za-zÀ-ÖØ-öø-ÿ]+([- ][A-Za-zÀ-ÖØ-öø-ÿ]+)*$/;
+
+function isValidName(value: string): boolean {
+  if (!value || value.trim().length === 0) return false;
+  if (value.length > 30) return false;
+  return NAME_PATTERN.test(value);
+}
+
+export interface ManualCoachRegistrationDialogProps {
+  /** Whether the dialog is visible. */
+  open: boolean;
+  /**
+   * Called when the user clicks "Ok" (with manually typed names) or after a successful PIN registration.
+   * Receives a CoachData object pre-populated with the coach's details.
+   */
+  onOk: (coachData: CoachData) => void;
+  /** Called when the user clicks "Cancel". Parent is responsible for showing a cancellation toast. */
+  onCancel: () => void;
+}
+
+/**
+ * Dialog for password-authenticated coaches to fill in their name for session registration.
+ * "Ok" is disabled until first name and last name are valid.
+ * "Register PIN code" opens RegisterPinDialog; on success, closes this dialog and calls onOk.
+ */
+export function ManualCoachRegistrationDialog({
+  open,
+  onOk,
+  onCancel,
+}: ManualCoachRegistrationDialogProps) {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const [firstname, setFirstname] = useState('');
+  const [lastname, setLastname] = useState('');
+  const [registerPinOpen, setRegisterPinOpen] = useState(false);
+  // Ref stores CoachData returned from registerCoachPin before onSuccess fires (avoids React state batching).
+  const pendingCoachDataRef = useRef<CoachData | null>(null);
+
+  // Reset fields when dialog opens.
+  useEffect(() => {
+    if (open) {
+      setFirstname('');
+      setLastname('');
+      setRegisterPinOpen(false);
+      pendingCoachDataRef.current = null;
+    }
+  }, [open]);
+
+  const isFormValid = isValidName(firstname) && isValidName(lastname);
+
+  function handleOk() {
+    if (!isFormValid) return;
+    const coachData: CoachData = {
+      id: '',
+      firstname: firstname.trim(),
+      lastname: lastname.trim(),
+      alias: '',
+      pin: '',
+      created_at: '',
+      last_activity: '',
+    };
+    onOk(coachData);
+  }
+
+  function handleCancel() {
+    setFirstname('');
+    setLastname('');
+    onCancel();
+  }
+
+  function handleOpenRegisterPin() {
+    setRegisterPinOpen(true);
+  }
+
+  async function handlePinRegister(data: RegisterPinData): Promise<void> {
+    const coachData = await registerCoachPin(data);
+    pendingCoachDataRef.current = coachData;
+  }
+
+  function handlePinRegistered(_pin: string) {
+    setRegisterPinOpen(false);
+    if (pendingCoachDataRef.current) {
+      onOk(pendingCoachDataRef.current);
+    }
+  }
+
+  function handlePinCancel() {
+    setRegisterPinOpen(false);
+    pendingCoachDataRef.current = null;
+  }
+
+  return (
+    <>
+      <Dialog
+        open={open}
+        aria-labelledby="manual-coach-registration-title"
+        onClose={handleCancel}
+        slotProps={{
+          paper: {
+            sx: {
+              background: theme.palette.background.default,
+              color: theme.palette.text.primary,
+              border: '2px solid',
+              borderColor: theme.palette.secondary.main,
+            },
+          },
+          backdrop: {
+            sx: {
+              backgroundColor: 'rgba(10, 10, 15, 0.85)',
+              backdropFilter: 'blur(8px)',
+              WebkitBackdropFilter: 'blur(8px)',
+            },
+          },
+        }}
+      >
+        <DialogTitle id="manual-coach-registration-title">
+          {t('manualCoachRegistration.title')}
+        </DialogTitle>
+
+        <DialogContent>
+          <Stack spacing={1} sx={{ mt: 0.5 }}>
+            <TextField
+              id="outlined-helpertext-firstname"
+              label={t('manualCoachRegistration.firstName')}
+              placeholder={t('manualCoachRegistration.firstNamePlaceholder')}
+              value={firstname}
+              onChange={e => setFirstname(e.target.value)}
+              required
+              inputProps={{ maxLength: 30, 'aria-label': t('manualCoachRegistration.firstName') }}
+              margin="dense"
+              fullWidth
+              sx={{
+                background: theme.palette.background.default,
+                color: theme.palette.text.primary,
+              }}
+            />
+            <TextField
+              id="outlined-helpertext-lastname"
+              label={t('manualCoachRegistration.lastName')}
+              placeholder={t('manualCoachRegistration.lastNamePlaceholder')}
+              value={lastname}
+              onChange={e => setLastname(e.target.value)}
+              required
+              inputProps={{ maxLength: 30, 'aria-label': t('manualCoachRegistration.lastName') }}
+              margin="dense"
+              fullWidth
+              sx={{
+                background: theme.palette.background.default,
+                color: theme.palette.text.primary,
+              }}
+            />
+          </Stack>
+
+          <Box sx={{ mt: 1 }}>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+              {t('manualCoachRegistration.pinHint')}
+            </Typography>
+            <Link
+              component="button"
+              variant="body2"
+              onClick={handleOpenRegisterPin}
+              sx={{ cursor: 'pointer' }}
+            >
+              {t('manualCoachRegistration.registerPinLink')}
+            </Link>
+          </Box>
+        </DialogContent>
+
+        <DialogActions>
+          <Box>
+            <ButtonGroup>
+              <Button
+                onClick={handleOk}
+                disabled={!isFormValid}
+                variant="contained"
+                color="primary"
+              >
+                {t('manualCoachRegistration.ok')}
+              </Button>
+              <Button
+                onClick={handleCancel}
+                variant="outlined"
+              >
+                {t('manualCoachRegistration.cancel')}
+              </Button>
+            </ButtonGroup>
+          </Box>
+        </DialogActions>
+      </Dialog>
+
+      <RegisterPinDialog
+        open={registerPinOpen}
+        onRegister={handlePinRegister}
+        onSuccess={handlePinRegistered}
+        onCancel={handlePinCancel}
+        initialFirstname={firstname}
+        initialLastname={lastname}
+      />
+    </>
+  );
+}

--- a/web/src/features/coach/components/__tests__/CoachLoginDialog.test.tsx
+++ b/web/src/features/coach/components/__tests__/CoachLoginDialog.test.tsx
@@ -45,7 +45,10 @@ const defaultProps = {
 describe('CoachLoginDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRegisterCoachPin.mockResolvedValue(undefined);
+    mockRegisterCoachPin.mockResolvedValue({
+      id: '1', firstname: 'John', lastname: 'Doe', alias: '', pin: '1234',
+      created_at: '2026-01-01T00:00:00Z', last_activity: '',
+    });
     mockVerifyCoachPin.mockResolvedValue({
       id: '1', firstname: 'John', lastname: 'Doe', alias: '', pin: '1234',
       created_at: '2026-01-01T00:00:00Z', last_activity: '',

--- a/web/src/features/coach/components/__tests__/ManualCoachRegistrationDialog.test.tsx
+++ b/web/src/features/coach/components/__tests__/ManualCoachRegistrationDialog.test.tsx
@@ -1,0 +1,224 @@
+/**
+ * @copyright 2026 Jouni Sipola by OQM. All rights reserved.
+ * Permission granted for personal/internal use only. Commercial
+ * use prohibited except by copyright holder. See LICENSE for details.
+ */
+
+/**
+ * @description Tests for ManualCoachRegistrationDialog (OQM-0010).
+ *   Covers: rendering, Ok button enable/disable, Cancel behaviour,
+ *   name transfer to RegisterPinDialog, and PIN registration success flow.
+ *   Written before implementation (TDD).
+ *   @see skills/SKILL.wire-react-to-gas.md
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import '../../../../lib/i18n';
+import { ManualCoachRegistrationDialog } from '../ManualCoachRegistrationDialog';
+
+// Mock the registerCoachPin API
+vi.mock('../../api/coach.api', () => ({
+  registerCoachPin: vi.fn(),
+}));
+
+import { registerCoachPin } from '../../api/coach.api';
+const mockRegisterCoachPin = vi.mocked(registerCoachPin);
+
+vi.mock('react-hot-toast', () => ({
+  default: { error: vi.fn(), success: vi.fn() },
+}));
+
+const defaultProps = {
+  open: true,
+  onOk: vi.fn(),
+  onCancel: vi.fn(),
+};
+
+const mockCoachData = {
+  id: 'coach-1',
+  firstname: 'John',
+  lastname: 'Doe',
+  alias: 'JD',
+  pin: '1234',
+  created_at: '2026-01-01T00:00:00Z',
+  last_activity: '',
+};
+
+describe('ManualCoachRegistrationDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Rendering ──────────────────────────────────────────────────────────────
+
+  it('does not render when open=false', () => {
+    render(<ManualCoachRegistrationDialog {...defaultProps} open={false} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders when open=true', () => {
+    render(<ManualCoachRegistrationDialog {...defaultProps} />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('displays title "Fill your information"', () => {
+    render(<ManualCoachRegistrationDialog {...defaultProps} />);
+    expect(screen.getByText('Fill your information')).toBeInTheDocument();
+  });
+
+  it('renders "First name:" input', () => {
+    render(<ManualCoachRegistrationDialog {...defaultProps} />);
+    expect(screen.getByLabelText('First name:')).toBeInTheDocument();
+  });
+
+  it('renders "Last name:" input', () => {
+    render(<ManualCoachRegistrationDialog {...defaultProps} />);
+    expect(screen.getByLabelText('Last name:')).toBeInTheDocument();
+  });
+
+  it('renders PIN hint text', () => {
+    render(<ManualCoachRegistrationDialog {...defaultProps} />);
+    expect(screen.getByText(/With personal PIN code/)).toBeInTheDocument();
+  });
+
+  it('renders "Register PIN code" link', () => {
+    render(<ManualCoachRegistrationDialog {...defaultProps} />);
+    expect(screen.getByRole('button', { name: 'Register PIN code' })).toBeInTheDocument();
+  });
+
+  it('renders "Ok" button', () => {
+    render(<ManualCoachRegistrationDialog {...defaultProps} />);
+    expect(screen.getByRole('button', { name: 'Ok' })).toBeInTheDocument();
+  });
+
+  it('renders "Cancel" button', () => {
+    render(<ManualCoachRegistrationDialog {...defaultProps} />);
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  // ── Ok button enable/disable ───────────────────────────────────────────────
+
+  it('"Ok" button is disabled when both fields are empty', () => {
+    render(<ManualCoachRegistrationDialog {...defaultProps} />);
+    expect(screen.getByRole('button', { name: 'Ok' })).toBeDisabled();
+  });
+
+  it('"Ok" button is disabled when only first name is filled', async () => {
+    render(<ManualCoachRegistrationDialog {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText('First name:'), 'John');
+    expect(screen.getByRole('button', { name: 'Ok' })).toBeDisabled();
+  });
+
+  it('"Ok" button is disabled when only last name is filled', async () => {
+    render(<ManualCoachRegistrationDialog {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText('Last name:'), 'Doe');
+    expect(screen.getByRole('button', { name: 'Ok' })).toBeDisabled();
+  });
+
+  it('"Ok" button is enabled when both valid names are filled', async () => {
+    render(<ManualCoachRegistrationDialog {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText('First name:'), 'John');
+    await userEvent.type(screen.getByLabelText('Last name:'), 'Doe');
+    expect(screen.getByRole('button', { name: 'Ok' })).not.toBeDisabled();
+  });
+
+  it('"Ok" button is disabled when name contains invalid characters', async () => {
+    render(<ManualCoachRegistrationDialog {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText('First name:'), 'Jo123');
+    await userEvent.type(screen.getByLabelText('Last name:'), 'Doe');
+    expect(screen.getByRole('button', { name: 'Ok' })).toBeDisabled();
+  });
+
+  // ── Ok button click (manual path) ─────────────────────────────────────────
+
+  it('clicking "Ok" calls onOk with CoachData built from form values', async () => {
+    render(<ManualCoachRegistrationDialog {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText('First name:'), 'John');
+    await userEvent.type(screen.getByLabelText('Last name:'), 'Doe');
+    await userEvent.click(screen.getByRole('button', { name: 'Ok' }));
+    expect(defaultProps.onOk).toHaveBeenCalledWith(
+      expect.objectContaining({ firstname: 'John', lastname: 'Doe' })
+    );
+  });
+
+  // ── Cancel button ──────────────────────────────────────────────────────────
+
+  it('clicking "Cancel" calls onCancel', async () => {
+    render(<ManualCoachRegistrationDialog {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(defaultProps.onCancel).toHaveBeenCalled();
+  });
+
+  it('clicking "Cancel" clears the form fields', async () => {
+    render(<ManualCoachRegistrationDialog {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText('First name:'), 'John');
+    await userEvent.type(screen.getByLabelText('Last name:'), 'Doe');
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(defaultProps.onCancel).toHaveBeenCalled();
+  });
+
+  it('clicking "Cancel" does not call onOk', async () => {
+    render(<ManualCoachRegistrationDialog {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText('First name:'), 'John');
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(defaultProps.onOk).not.toHaveBeenCalled();
+  });
+
+  // ── Register PIN code link ─────────────────────────────────────────────────
+
+  it('clicking "Register PIN code" link opens RegisterPinDialog', async () => {
+    render(<ManualCoachRegistrationDialog {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Register PIN code' }));
+    expect(screen.getByText('Register new PIN code')).toBeInTheDocument();
+  });
+
+  it('names filled before clicking link are transferred to RegisterPinDialog', async () => {
+    render(<ManualCoachRegistrationDialog {...defaultProps} />);
+    await userEvent.type(screen.getByLabelText('First name:'), 'Anna');
+    await userEvent.type(screen.getByLabelText('Last name:'), 'Smith');
+    await userEvent.click(screen.getByRole('button', { name: 'Register PIN code' }));
+    // RegisterPinDialog should have the pre-filled names
+    expect(screen.getByLabelText('Firstname')).toHaveValue('Anna');
+    expect(screen.getByLabelText('Lastname')).toHaveValue('Smith');
+  });
+
+  it('RegisterPinDialog opens with empty fields when names are not filled', async () => {
+    render(<ManualCoachRegistrationDialog {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Register PIN code' }));
+    expect(screen.getByLabelText('Firstname')).toHaveValue('');
+    expect(screen.getByLabelText('Lastname')).toHaveValue('');
+  });
+
+  // ── PIN registration success flow ──────────────────────────────────────────
+
+  it('successful PIN registration calls onOk with CoachData from API', async () => {
+    mockRegisterCoachPin.mockResolvedValue(mockCoachData);
+    render(<ManualCoachRegistrationDialog {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Register PIN code' }));
+
+    // Fill RegisterPinDialog fields
+    await userEvent.type(screen.getByLabelText('Firstname'), 'John');
+    await userEvent.type(screen.getByLabelText('Lastname'), 'Doe');
+    await userEvent.type(screen.getByLabelText('Enter new PIN code'), '1234');
+    await userEvent.type(screen.getByLabelText('Enter PIN again'), '1234');
+    await userEvent.click(screen.getByRole('button', { name: 'Register' }));
+
+    await waitFor(() => {
+      expect(defaultProps.onOk).toHaveBeenCalledWith(mockCoachData);
+    });
+  });
+
+  it('cancelling RegisterPinDialog keeps ManualCoachRegistrationDialog open', async () => {
+    render(<ManualCoachRegistrationDialog {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Register PIN code' }));
+    // Cancel the RegisterPinDialog
+    const cancelButtons = screen.getAllByRole('button', { name: 'Cancel' });
+    // The RegisterPinDialog Cancel button should be present
+    await userEvent.click(cancelButtons[cancelButtons.length - 1]);
+    // ManualCoachRegistrationDialog should still be rendered
+    expect(screen.getByText('Fill your information')).toBeInTheDocument();
+  });
+});

--- a/web/src/features/coach/index.ts
+++ b/web/src/features/coach/index.ts
@@ -6,4 +6,5 @@ export { CoachLoginDialog } from './components/CoachLoginDialog';
 export { SessionCard } from './components/SessionCard';
 export { ConfirmCoachRegistrationDialog } from './components/ConfirmCoachRegistrationDialog';
 export { ConfirmRemoveCoachDialog } from './components/ConfirmRemoveCoachDialog';
+export { ManualCoachRegistrationDialog } from './components/ManualCoachRegistrationDialog';
 export type { CoachLoginDialogProps, CoachData, SessionItem, RegisterCoachForSessionPayload } from './types';

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -78,5 +78,14 @@
   "coachQuickRegistration.concurrentOperation": "Concurrent operation ongoing. Refresh page before trying again.",
   "coachQuickRegistration.sessionAvailable": "Session already without registered coach. Refresh page.",
   "coachQuickRegistration.registrationNotFound": "Registration not found. Refresh page.",
-  "coachQuickRegistration.removalCancelled": "Registration removal cancelled."
+  "coachQuickRegistration.removalCancelled": "Registration removal cancelled.",
+  "manualCoachRegistration.title": "Fill your information",
+  "manualCoachRegistration.firstName": "First name:",
+  "manualCoachRegistration.firstNamePlaceholder": "Your first name",
+  "manualCoachRegistration.lastName": "Last name:",
+  "manualCoachRegistration.lastNamePlaceholder": "Your last name",
+  "manualCoachRegistration.pinHint": "With personal PIN code, you speed up and simplify your registration.",
+  "manualCoachRegistration.registerPinLink": "Register PIN code",
+  "manualCoachRegistration.ok": "Ok",
+  "manualCoachRegistration.cancel": "Cancel"
 }

--- a/web/src/locales/fi.json
+++ b/web/src/locales/fi.json
@@ -78,5 +78,14 @@
   "coachQuickRegistration.concurrentOperation": "Samanaikainen operaatio käynnissä. Päivitä sivu ennen kuin yrität uudelleen.",
   "coachQuickRegistration.sessionAvailable": "Harjoituksella ei ole rekisteröitynyttä valmentajaa. Päivitä sivu.",
   "coachQuickRegistration.registrationNotFound": "Ilmoittautumista ei löydy. Päivitä sivu.",
-  "coachQuickRegistration.removalCancelled": "Ilmoittautumisen poistaminen peruutettu."
+  "coachQuickRegistration.removalCancelled": "Ilmoittautumisen poistaminen peruutettu.",
+  "manualCoachRegistration.title": "Täytä tietosi",
+  "manualCoachRegistration.firstName": "Etunimi:",
+  "manualCoachRegistration.firstNamePlaceholder": "Oma etunimi",
+  "manualCoachRegistration.lastName": "Sukunimi:",
+  "manualCoachRegistration.lastNamePlaceholder": "Oma sukunimi",
+  "manualCoachRegistration.pinHint": "Henkilökohtaisella PIN-koodilla nopeutat ja yksinkertaistat ilmoittautumistasi.",
+  "manualCoachRegistration.registerPinLink": "Rekisteröi PIN-koodi",
+  "manualCoachRegistration.ok": "Ok",
+  "manualCoachRegistration.cancel": "Peruuta"
 }

--- a/web/src/pages/Coach/CoachPage.tsx
+++ b/web/src/pages/Coach/CoachPage.tsx
@@ -22,6 +22,7 @@ import { LoadingOverlay } from '../../shared/components/LoadingOverlay/LoadingOv
 import { SessionCard } from '../../features/coach/components/SessionCard';
 import { ConfirmCoachRegistrationDialog } from '../../features/coach/components/ConfirmCoachRegistrationDialog';
 import { ConfirmRemoveCoachDialog } from '../../features/coach/components/ConfirmRemoveCoachDialog';
+import { ManualCoachRegistrationDialog } from '../../features/coach/components/ManualCoachRegistrationDialog';
 import { getCoachSessions } from '../../features/coach/api/coach.api';
 import type { CoachData, SessionItem } from '../../features/coach/types';
 
@@ -49,7 +50,10 @@ export function CoachPage({ onBack, coachData }: CoachPageProps) {
   const [error, setError] = useState<string | null>(null);
   const [confirmRegisterOpen, setConfirmRegisterOpen] = useState(false);
   const [confirmRemoveOpen, setConfirmRemoveOpen] = useState(false);
+  const [manualRegisterOpen, setManualRegisterOpen] = useState(false);
   const [selectedSession, setSelectedSession] = useState<SessionItem | null>(null);
+  // Temporary CoachData built from manual name entry or PIN registration (OQM-0010).
+  const [pendingCoachData, setPendingCoachData] = useState<CoachData | undefined>(undefined);
 
   const fetchSessions = useCallback(async () => {
     setLoading(true);
@@ -84,7 +88,13 @@ export function CoachPage({ onBack, coachData }: CoachPageProps) {
 
   function handleRegister(session: SessionItem) {
     setSelectedSession(session);
-    setConfirmRegisterOpen(true);
+    if (coachData) {
+      // PIN-authenticated coach: go directly to confirmation dialog.
+      setConfirmRegisterOpen(true);
+    } else {
+      // Password-authenticated coach: collect name first (OQM-0010).
+      setManualRegisterOpen(true);
+    }
   }
 
   function handleRemove(session: SessionItem) {
@@ -94,15 +104,16 @@ export function CoachPage({ onBack, coachData }: CoachPageProps) {
 
   function handleRegisterSuccess(registrationId: string) {
     setConfirmRegisterOpen(false);
-    if (selectedSession && coachData) {
-      const coachName = coachData.alias || `${coachData.firstname} ${coachData.lastname}`;
+    const activeCoach = coachData || pendingCoachData;
+    if (selectedSession && activeCoach) {
+      const coachName = activeCoach.alias || `${activeCoach.firstname} ${activeCoach.lastname}`;
       setSessions(prev =>
         prev.map(s =>
           s.id === selectedSession.id
             ? {
                 ...s,
-                coach_firstname: coachData.firstname,
-                coach_lastname: coachData.lastname,
+                coach_firstname: activeCoach.firstname,
+                coach_lastname: activeCoach.lastname,
                 coach_alias: coachName,
                 registration_id: registrationId,
               }
@@ -111,10 +122,24 @@ export function CoachPage({ onBack, coachData }: CoachPageProps) {
       );
     }
     setSelectedSession(null);
+    setPendingCoachData(undefined);
   }
 
   function handleRegisterCancel() {
     setConfirmRegisterOpen(false);
+    setSelectedSession(null);
+    setPendingCoachData(undefined);
+    toast(t('coachQuickRegistration.registrationCancelled'));
+  }
+
+  function handleManualRegisterOk(newCoachData: CoachData) {
+    setManualRegisterOpen(false);
+    setPendingCoachData(newCoachData);
+    setConfirmRegisterOpen(true);
+  }
+
+  function handleManualRegisterCancel() {
+    setManualRegisterOpen(false);
     setSelectedSession(null);
     toast(t('coachQuickRegistration.registrationCancelled'));
   }
@@ -194,9 +219,15 @@ export function CoachPage({ onBack, coachData }: CoachPageProps) {
       <ConfirmCoachRegistrationDialog
         open={confirmRegisterOpen}
         session={selectedSession}
-        coachData={coachData}
+        coachData={coachData ?? pendingCoachData}
         onSuccess={handleRegisterSuccess}
         onCancel={handleRegisterCancel}
+      />
+
+      <ManualCoachRegistrationDialog
+        open={manualRegisterOpen}
+        onOk={handleManualRegisterOk}
+        onCancel={handleManualRegisterCancel}
       />
 
       <ConfirmRemoveCoachDialog

--- a/web/src/pages/Coach/__tests__/CoachPage.test.tsx
+++ b/web/src/pages/Coach/__tests__/CoachPage.test.tsx
@@ -119,12 +119,21 @@ describe('CoachPage', () => {
     });
   });
 
-  it('shows ConfirmCoachRegistrationDialog when Register is clicked', async () => {
+  it('shows ConfirmCoachRegistrationDialog when Register is clicked (PIN-authenticated coach)', async () => {
+    const coachData = { id: '1', firstname: 'John', lastname: 'Doe', alias: 'JD', pin: '1234', created_at: '', last_activity: '' };
+    mockGetCoachSessions.mockResolvedValue([mockSession]);
+    render(<CoachPage onBack={vi.fn()} coachData={coachData} />);
+    await waitFor(() => screen.getByRole('button', { name: 'Register' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Register' }));
+    expect(screen.getByText('Confirm Registration')).toBeInTheDocument();
+  });
+
+  it('shows ManualCoachRegistrationDialog when Register is clicked (password-authenticated coach)', async () => {
     mockGetCoachSessions.mockResolvedValue([mockSession]);
     render(<CoachPage onBack={vi.fn()} />);
     await waitFor(() => screen.getByRole('button', { name: 'Register' }));
     await userEvent.click(screen.getByRole('button', { name: 'Register' }));
-    expect(screen.getByText('Confirm Registration')).toBeInTheDocument();
+    expect(screen.getByText('Fill your information')).toBeInTheDocument();
   });
 
   it('shows ConfirmRemoveCoachDialog when Remove is clicked', async () => {

--- a/web/src/shared/components/RegisterPinDialog/RegisterPinDialog.tsx
+++ b/web/src/shared/components/RegisterPinDialog/RegisterPinDialog.tsx
@@ -21,6 +21,8 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogActions from '@mui/material/DialogActions';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
+import ButtonGroup from '@mui/material/ButtonGroup';
+import Box from '@mui/material/Box';
 import { LoadingOverlay } from '../LoadingOverlay/LoadingOverlay';
 
 const PIN_PATTERN = /^\d{4,6}$/;
@@ -57,6 +59,10 @@ export interface RegisterPinDialogProps {
   onCancel: () => void;
   /** Whether to show the Alias input field. Defaults to true. */
   showAlias?: boolean;
+  /** Pre-fill the Firstname field when the dialog opens (OQM-0010). */
+  initialFirstname?: string;
+  /** Pre-fill the Lastname field when the dialog opens (OQM-0010). */
+  initialLastname?: string;
 }
 
 /**
@@ -70,6 +76,8 @@ export function RegisterPinDialog({
   onSuccess,
   onCancel,
   showAlias = true,
+  initialFirstname = '',
+  initialLastname = '',
 }: RegisterPinDialogProps) {
   const { t } = useTranslation();
   const theme = useTheme();
@@ -82,11 +90,11 @@ export function RegisterPinDialog({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [pinReservedOpen, setPinReservedOpen] = useState(false);
 
-  // Reset form state each time the dialog opens.
+  // Reset form state each time the dialog opens; pre-fill names when provided (OQM-0010).
   useEffect(() => {
     if (open) {
-      setFirstname('');
-      setLastname('');
+      setFirstname(initialFirstname);
+      setLastname(initialLastname);
       setAlias('');
       setPin('');
       setPinAgain('');
@@ -94,7 +102,7 @@ export function RegisterPinDialog({
       setIsSubmitting(false);
       setPinReservedOpen(false);
     }
-  }, [open]);
+  }, [open, initialFirstname, initialLastname]);
 
   function markDirty(field: string) {
     setDirty(prev => ({ ...prev, [field]: true }));
@@ -296,29 +304,35 @@ export function RegisterPinDialog({
           />
         </DialogContent>
         <DialogActions>
-          <Button 
-            onClick={handleRegister} 
-            disabled={!isFormValid || isSubmitting} 
-            variant="contained"
-            sx={{ 
-              whiteSpace: 'nowrap', 
-              background: theme.palette.background.default,
-              color: theme.palette.text.primary,
-              borderColor: theme.palette.primary.main,                
-            }}
-          >
-            {t('registerPin.register')}
-          </Button>
-          <Button 
-            onClick={onCancel}
-            sx={{
-              background: theme.palette.primary.main,
-              color: theme.palette.text.primary,
-              borderColor: theme.palette.primary.main,
-            }}
-          >
-            {t('registerPin.cancel')}
-          </Button>
+          <Box>
+            <ButtonGroup>
+              <Button 
+                onClick={handleRegister} 
+                disabled={!isFormValid || isSubmitting} 
+                variant="contained"
+                color="primary"
+//                sx={{ 
+//                  whiteSpace: 'nowrap', 
+//                  background: theme.palette.background.default,
+//                  color: theme.palette.text.primary,
+//                  borderColor: theme.palette.primary.main,                
+//                }}
+              >
+                {t('registerPin.register')}
+              </Button>
+              <Button 
+                onClick={onCancel}
+                variant="outlined"
+//                sx={{
+//                  background: theme.palette.primary.main,
+//                  color: theme.palette.text.primary,
+//                  borderColor: theme.palette.primary.main,
+//                }}
+              >
+                {t('registerPin.cancel')}
+              </Button>
+            </ButtonGroup>
+          </Box>
         </DialogActions>
         <LoadingOverlay visible={isSubmitting} />
       </Dialog>


### PR DESCRIPTION

- Added ManualCoachRegistrationDialog component for password-authenticated coaches to register for sessions.
- Integrated RegisterPinDialog for PIN registration, pre-filling name fields.
- Updated registerCoachPin API to return CoachData on successful registration.
- Enhanced tests for ManualCoachRegistrationDialog to cover rendering, button states, and PIN registration flow.
- Updated localization files for new dialog texts.
- Documented user story OQM-0010 for manual coach registration process.

## Summary
- Linked issue: #20

## Checklist
- [x] Tests added/updated and passing
- [x] No secrets committed
- [x] API contract adhered to
- [x] Updated docs/skills if schema or flows changed
