### PR TITLE
OQM-0018 Implement verifyTraineePin API function and associated tests for trainee PIN verification

### DIFF
--- a/user_stories/trainee/OQM-0018-verify-trainee-pin-code-part1/OQM-0018-verify-trainee-pin-code-part1.md
+++ b/user_stories/trainee/OQM-0018-verify-trainee-pin-code-part1/OQM-0018-verify-trainee-pin-code-part1.md
@@ -1,0 +1,63 @@
+**Title:**
+OQM-0018 Verify Trainee PIN Code - part 1
+
+**Description:**  
+Enable trainee pin code verification by implementing new API function in [trainee.api.ts](web/src/features/trainee/api/trainee.api.ts) for trainee PIN verification.
+
+**User Story:**  
+As a trainee, I want to enable verification of personal PIN code so that I can in the future login and register for training sessions easier.
+
+**New Trainee API Function**
+- Implement API function for trainee PIN verification in [trainee.api.ts](web/src/features/trainee/api/trainee.api.ts)
+- Use `verifyCoachPin(pin: string)` located in [coach.api.ts](web/src/features/coach/api/coach.api.ts) for reference
+- route: 'verifyTraineePin'
+- Payload content:
+    - pin: trainee's pin code to be verified
+        - String value (4-6 digits)
+        - Required
+- Success returns payload containing
+    - id: row id
+    - firstname: first name of the trainee
+    - lastname: last name of the trainee
+    - age: age of the underage trainee
+    - pin: pin code
+    - created_at: date when row was appended,
+    - last_activity: date when trainee last logged in using pin code
+- Failure throws error if backend operation failed
+    - 'no_match_found' in case no matching pin was found
+
+**Test Cases:**  
+- Unit: throws error when `VITE_GAS_BASE_URL` is not configured.
+- Unit: sends POST request with correct shape:
+    - URL = `VITE_GAS_BASE_URL`
+    - `method: 'POST'`
+    - `redirect: 'follow'`
+    - `headers: { 'Content-Type': 'text/plain;charset=utf-8' }`
+    - body includes `{ route: 'verifyTraineePin', payload: { pin }, token }`
+- Unit: successful response (`ok: true`) returns payload.
+- Unit: backend error `no_match_found` is thrown as Error(`no_match_found`).
+- Unit: backend error `Unauthorized` is thrown as Error(`Unauthorized`).
+- Unit: fallback error is thrown when backend returns `ok: false` without error string.
+- Unit: network failure from fetch is propagated as rejection.
+
+**Acceptance Criteria:**  
+- New API function `verifyTraineePin` is implemented in [trainee.api.ts](web/src/features/trainee/api/trainee.api.ts).
+- Function uses GAS POST conventions:
+    - `redirect: 'follow'`
+    - `Content-Type: 'text/plain;charset=utf-8'`
+    - body format `{ route, payload, token }`
+- Function calls route `verifyTraineePin`.
+- Payload contract is respected:
+    - `pin` (required, string)
+- Function returns created payload on success.
+- Function throws backend error code/message when response is `ok: false`.
+- Function throws clear configuration error when `VITE_GAS_BASE_URL` is missing.
+- Tests are added/updated in trainee API test suite and cover:
+    - success path
+    - request shape
+    - key backend error paths
+- Contract alignment is verified against [SKILL.wire-react-to-gas.md](skills/SKILL.wire-react-to-gas.md).
+
+**Linked Files/Branches:**  
+- [trainee.api.ts](web/src/features/trainee/api/trainee.api.ts)
+- [coach.api.ts](web/src/features/coach/api/coach.api.ts)

--- a/user_stories/trainee/OQM-0018-verify-trainee-pin-code-part1/prompt.md
+++ b/user_stories/trainee/OQM-0018-verify-trainee-pin-code-part1/prompt.md
@@ -1,0 +1,4 @@
+Implement the feature described in GitHub issue #34:
+- Follow [SKILL.wire-react-to-gas.md](http://_vscodecontentref_/0) for API contract
+- Apply all relevant instructions from [copilot-instructions.md](http://_vscodecontentref_/1) and [frontend.instructions.md](http://_vscodecontentref_/2)
+- Use TDD and update documentation as required

--- a/web/src/features/trainee/api/__tests__/trainee.api.test.ts
+++ b/web/src/features/trainee/api/__tests__/trainee.api.test.ts
@@ -10,7 +10,12 @@
  *   @see skills/SKILL.wire-react-to-gas.md
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getTraineeSessions, registerTraineeForSession, registerTraineePin } from '../trainee.api';
+import {
+  getTraineeSessions,
+  registerTraineeForSession,
+  registerTraineePin,
+  verifyTraineePin,
+} from '../trainee.api';
 import type { RegisterTraineeForSessionPayload } from '../../types';
 
 const mockFetch = vi.fn();
@@ -161,6 +166,98 @@ describe('registerTraineePin', () => {
     await expect(
       registerTraineePin({ firstname: 'Jane', lastname: 'Doe', age: '12', pin: '1234' })
     ).rejects.toThrow('network down');
+  });
+});
+
+describe('verifyTraineePin', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_GAS_BASE_URL', BASE);
+    vi.stubEnv('VITE_API_TOKEN', TOKEN);
+    mockFetch.mockReset();
+  });
+
+  it('throws when VITE_GAS_BASE_URL is not configured', async () => {
+    vi.stubEnv('VITE_GAS_BASE_URL', '');
+
+    await expect(verifyTraineePin('1234')).rejects.toThrow('VITE_GAS_BASE_URL is not configured');
+  });
+
+  it('sends a POST request with correct shape', async () => {
+    const traineeData = {
+      id: 'trainee-1',
+      firstname: 'Jane',
+      lastname: 'Doe',
+      age: '12',
+      pin: '1234',
+      created_at: '2026-01-01T00:00:00Z',
+      last_activity: '2026-01-10T10:00:00Z',
+    };
+    mockFetch.mockResolvedValue({
+      json: async () => ({ ok: true, data: traineeData }),
+    });
+
+    await verifyTraineePin('1234');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      BASE,
+      expect.objectContaining({
+        method: 'POST',
+        redirect: 'follow',
+        headers: { 'Content-Type': 'text/plain;charset=utf-8' },
+        body: JSON.stringify({
+          route: 'verifyTraineePin',
+          payload: { pin: '1234' },
+          token: TOKEN,
+        }),
+      })
+    );
+  });
+
+  it('returns trainee data when backend returns ok: true', async () => {
+    const traineeData = {
+      id: 'trainee-1',
+      firstname: 'Jane',
+      lastname: 'Doe',
+      age: '12',
+      pin: '1234',
+      created_at: '2026-01-01T00:00:00Z',
+      last_activity: '2026-01-10T10:00:00Z',
+    };
+    mockFetch.mockResolvedValue({
+      json: async () => ({ ok: true, data: traineeData }),
+    });
+
+    await expect(verifyTraineePin('1234')).resolves.toEqual(traineeData);
+  });
+
+  it('throws "no_match_found" when backend returns that error', async () => {
+    mockFetch.mockResolvedValue({
+      json: async () => ({ ok: false, error: 'no_match_found' }),
+    });
+
+    await expect(verifyTraineePin('1234')).rejects.toThrow('no_match_found');
+  });
+
+  it('throws backend error message on unauthorized responses', async () => {
+    mockFetch.mockResolvedValue({
+      json: async () => ({ ok: false, error: 'Unauthorized' }),
+    });
+
+    await expect(verifyTraineePin('1234')).rejects.toThrow('Unauthorized');
+  });
+
+  it('throws fallback error when backend returns ok false without error string', async () => {
+    mockFetch.mockResolvedValue({
+      json: async () => ({ ok: false }),
+    });
+
+    await expect(verifyTraineePin('1234')).rejects.toThrow('Verification failed');
+  });
+
+  it('propagates network failures', async () => {
+    mockFetch.mockRejectedValue(new Error('network down'));
+
+    await expect(verifyTraineePin('1234')).rejects.toThrow('network down');
   });
 });
 

--- a/web/src/features/trainee/api/trainee.api.ts
+++ b/web/src/features/trainee/api/trainee.api.ts
@@ -43,6 +43,29 @@ export async function registerTraineePin(data: RegisterTraineePinData): Promise<
 }
 
 /**
+ * Verify a trainee PIN code against the GAS backend.
+ * POST { route: "verifyTraineePin", payload: { pin }, token }
+ * Returns trainee data on success.
+ * Throws Error('no_match_found') if the PIN does not match any trainee.
+ * Throws other Errors for network/service failures.
+ * @see skills/SKILL.wire-react-to-gas.md
+ */
+export async function verifyTraineePin(pin: string): Promise<TraineeData> {
+  const base = import.meta.env.VITE_GAS_BASE_URL as string;
+  const token = import.meta.env.VITE_API_TOKEN as string;
+  if (!base) throw new Error('VITE_GAS_BASE_URL is not configured');
+  const res = await fetch(base, {
+    method: 'POST',
+    redirect: 'follow',
+    headers: { 'Content-Type': 'text/plain;charset=utf-8' },
+    body: JSON.stringify({ route: 'verifyTraineePin', payload: { pin }, token }),
+  });
+  const json = await res.json();
+  if (!json.ok) throw new Error(json.error || 'Verification failed');
+  return json.data as TraineeData;
+}
+
+/**
  * Fetch all trainee sessions for the active 21-day registration window.
  * GET ?route=getTraineeSessions&token=...
  * Returns array of TraineeSessionItem sorted by date and start_time.

--- a/web/src/features/trainee/index.ts
+++ b/web/src/features/trainee/index.ts
@@ -8,6 +8,7 @@
  * @description Public exports for the trainee feature (OQM-0014).
  */
 export { registerTraineePin } from './api/trainee.api';
+export { verifyTraineePin } from './api/trainee.api';
 export { registerTraineeForSession } from './api/trainee.api';
 export { getTraineeSessions } from './api/trainee.api';
 export type {


### PR DESCRIPTION
## Summary
- Linked issue: #34 
- Added new API function verifyTraineePin in trainee.api.ts.
- Added TDD coverage for verifyTraineePin in trainee.api.test.ts
- Exported verifyTraineePin from index.ts
- Updated issue documentation to match the contract route and payload type

### Notes:
- Implementation follows GAS POST conventions (redirect follow, Content-Type text/plain;charset=utf-8, body shape route/payload/token).
- Route used is verifyTraineePin per SKILL contract. 
 
 ## Checklist
 [ ] Tests added/updated and passing
 [ ] No secrets committed
 [ ] API contract adhered to
 [ ] Updated docs/skills if schema or flows changed