### PR TITLE
feat(manuals): OQM-0021 create user manuals for trainee and coach in English and Finnish

### DIFF
--- a/.github/instructions/copilot-instructions.md
+++ b/.github/instructions/copilot-instructions.md
@@ -52,6 +52,19 @@ You are collaborating on a React (Vite) + Google Apps Script + Google Sheets sys
 - For each issue, create a dedicated branch named after the issue (e.g., feature/issue-123-description). Implement the feature or fix in this branch. Open a PR to merge into main/master only after review and CI checks pass.
 - Remove unused imports and variables before committing changes into the repository to keep code clean and maintainable.
 
+## User Manuals Maintenance (user-visible features)
+- If a feature changes anything a user can see or do in the UI (new page, dialog, button behavior, labels/messages, flows, error handling), create or update manuals in `user_manuals/` as part of the same task.
+- Maintain both languages when applicable:
+	- English manuals: `*.en.md`
+	- Finnish manuals: `*.fi.md`
+- Keep manuals user-focused and non-technical:
+	- Describe what the user clicks, enters, and sees.
+	- Include expected outcomes and error recovery steps.
+	- Do not include backend/API/sheet/deployment details.
+- Keep terminology aligned with current UI localization text.
+- When behavior is intentionally not yet implemented, state it clearly in manuals (for example: "not yet available").
+- In each PR that changes user-visible behavior, include a short "Manual impact" note listing which manual files were created/updated.
+
 ## Output Expectations
 - When generating code, include a brief rationale and a test outline in PRs and comments.
 - Reference the relevant SKILL doc in code comments, PRs, and documentation updates.

--- a/.github/instructions/review-checklist.instructions.md
+++ b/.github/instructions/review-checklist.instructions.md
@@ -1,5 +1,6 @@
 # PR Review Checklist (Agent + Human)
 - [ ] Documentation updated (skills/ and instructions)
+- [ ] User manuals updated for user-visible changes (`user_manuals/*.en.md`, `user_manuals/*.fi.md`)
 - [ ] Relevant skill docs referenced in PR and code comments
 - [ ] Test coverage for new/changed code
 - [ ] Contract compliance verified

--- a/user_manuals/coach-manual.en.md
+++ b/user_manuals/coach-manual.en.md
@@ -1,0 +1,85 @@
+# Coach User Manual (English)
+
+## Purpose
+This manual helps coaches log in and manage coach registrations for sessions.
+
+## Prerequisites
+- You can open the application main view.
+- You have either:
+  - a coach PIN code, or
+  - the coach password.
+
+## Main Flow: Open Coach Quick Registration
+1. Open the app main view.
+2. Select Coaches.
+3. In the login dialog, either:
+   - enter PIN and select Verify, or
+   - enter password and select Login.
+
+Expected result:
+- You enter Coach Quick Registration.
+- Session cards are shown in date groups.
+
+## Register as Coach for a Session
+1. On Coach Quick Registration, find a session card.
+2. Select Register on a session without a coach.
+3. If asked, provide your name details.
+4. Review details in Confirm Registration dialog.
+5. Select Confirm.
+
+Expected result:
+- You see Registration successful.
+- Card changes to a registered state with coach details.
+
+## Remove Coach Registration
+1. Find a session where you are already registered.
+2. Select Remove.
+3. Read the warning in the confirmation dialog.
+4. Select Confirm to remove.
+
+Expected result:
+- You see Registration removed successfully.
+- Session card returns to available state.
+
+## Create a Free/Sparring Session
+1. Select Free/sparring session.
+2. Fill first name, last name, date, start time, and end time.
+3. Select Confirm.
+4. Confirm the registration in the next dialog.
+
+Expected result:
+- A new free/sparring registration is created.
+- If the date is outside the visible window, you are informed it will appear when in range.
+
+## Register New PIN Code (Coach)
+1. In Coach login dialog, select Register new PIN code.
+2. Fill first name, last name, optional alias, and PIN fields.
+3. Select Register.
+4. Return to login and verify with the new PIN.
+
+## Other Useful Actions
+- Refresh data: reloads the current session list.
+- Back to main: exits coach page.
+
+## Error and Recovery
+- Invalid PIN. Try again.
+  - Re-enter PIN and verify.
+- Incorrect password. Try again.
+  - Re-enter password carefully.
+- Session already has a registered coach. Refresh page.
+  - Select Refresh data and choose another session if needed.
+- Overlapping session found.
+  - Adjust free/sparring date or time and retry.
+- Concurrent operation ongoing. Refresh page before trying again.
+  - Refresh and retry.
+
+## Notes About Session Cards
+- Green card means a coach is assigned.
+- Non-green card means session is available.
+- Free/sparring cards without coach cannot be claimed with Register button.
+  - Use Free/sparring session action to create and register one.
+
+## Quick Tips
+- Use PIN login for faster access.
+- Use alias when you want a preferred display name.
+- Refresh data before changes if multiple people are updating sessions.

--- a/user_manuals/coach-manual.fi.md
+++ b/user_manuals/coach-manual.fi.md
@@ -1,0 +1,85 @@
+# Valmentajan käyttöohje (suomi)
+
+## Tarkoitus
+Tämä ohje auttaa valmentajaa kirjautumaan ja hallitsemaan valmentajien ilmoittautumisia harjoituksiin.
+
+## Ennen aloittamista
+- Pääset sovelluksen etusivulle.
+- Sinulla on joko:
+  - valmentajan PIN-koodi, tai
+  - valmentajan salasana.
+
+## Pääpolku: Avaa valmentajan pikailmoittautuminen
+1. Avaa sovelluksen etusivu.
+2. Valitse Valmentajat.
+3. Kirjautumisikkunassa joko:
+   - syötä PIN ja valitse Tarkista, tai
+   - syötä salasana ja valitse Kirjaudu.
+
+Odotettu tulos:
+- Siirryt valmentajan pikailmoittautumiseen.
+- Harjoituskortit näkyvät päivittäin ryhmiteltyinä.
+
+## Ilmoittaudu valmentajaksi harjoitukseen
+1. Etsi valmentajasivulta harjoituskortti.
+2. Valitse Ilmoittaudu kortilta, jossa ei ole valmentajaa.
+3. Anna tarvittaessa nimitiedot.
+4. Tarkista tiedot Vahvista ilmoittautuminen -ikkunassa.
+5. Valitse Vahvista.
+
+Odotettu tulos:
+- Näet viestin Ilmoittautuminen onnistui.
+- Kortti päivittyy valmentajan tiedoilla.
+
+## Poista valmentajan ilmoittautuminen
+1. Etsi harjoitus, jossa valmentaja on jo ilmoittautunut.
+2. Valitse Poista.
+3. Lue varoitus vahvistusikkunassa.
+4. Valitse Vahvista poistaaksesi ilmoittautumisen.
+
+Odotettu tulos:
+- Näet viestin Ilmoittautuminen poistettu onnistuneesti.
+- Kortti palautuu vapaaseen tilaan.
+
+## Luo vapaa/sparraus-harjoitus
+1. Valitse Vapaa/sparraus.
+2. Täytä etunimi, sukunimi, päivämäärä, aloitusaika ja lopetusaika.
+3. Valitse Vahvista.
+4. Vahvista ilmoittautuminen seuraavassa ikkunassa.
+
+Odotettu tulos:
+- Uusi vapaa/sparraus-ilmoittautuminen luodaan.
+- Jos päivä on näkyvän aikajakson ulkopuolella, saat siitä ilmoituksen.
+
+## Rekisteröi uusi PIN-koodi (valmentaja)
+1. Valitse valmentajan kirjautumisikkunassa Rekisteröi uusi PIN-koodi.
+2. Täytä etunimi, sukunimi, mahdollinen alias ja PIN-kentät.
+3. Valitse Rekisteröi.
+4. Palaa kirjautumiseen ja tarkista uusi PIN.
+
+## Muut hyödylliset toiminnot
+- Päivitä tiedot: lataa harjoituslista uudelleen.
+- Takaisin etusivulle: poistu valmentajasivulta.
+
+## Virheet ja toipuminen
+- Virheellinen PIN-koodi. Yritä uudelleen.
+  - Syötä PIN uudelleen ja tarkista.
+- Väärä salasana. Yritä uudelleen.
+  - Syötä salasana uudelleen huolellisesti.
+- Harjoituksella on jo ilmoittautunut valmentaja. Päivitä sivu.
+  - Valitse Päivitä tiedot ja valitse tarvittaessa toinen harjoitus.
+- Päällekkäinen harjoitus löytyi.
+  - Muuta vapaa/sparraus-harjoituksen aikaa tai päivää ja yritä uudelleen.
+- Samanaikainen operaatio käynnissä. Päivitä sivu ennen kuin yrität uudelleen.
+  - Päivitä ja yritä uudelleen.
+
+## Huomiot harjoituskorteista
+- Vihreä kortti tarkoittaa, että valmentaja on asetettu.
+- Muu väri tarkoittaa, että harjoitus on vapaa.
+- Vapaa/sparraus-korttia ilman valmentajaa ei voi ottaa Ilmoittaudu-painikkeella.
+  - Luo harjoitus Vapaa/sparraus-toiminnolla.
+
+## Pikaohjeet
+- Käytä PIN-kirjautumista nopeaan käyttöön.
+- Käytä aliasta, jos haluat tietyn näyttönimen.
+- Päivitä tiedot ennen muutoksia, jos useampi henkilö käyttää järjestelmää samaan aikaan.

--- a/user_manuals/trainee-manual.en.md
+++ b/user_manuals/trainee-manual.en.md
@@ -1,0 +1,73 @@
+# Trainee User Manual (English)
+
+## Purpose
+This manual helps trainees use the application to log in and register for training sessions.
+
+## Prerequisites
+- You can open the application main view.
+- You know your name details.
+- If you already have a PIN, keep it available.
+
+## Main Flow: Register for a Session
+1. Open the app main view.
+2. Select Trainees.
+3. Wait until sessions are loaded.
+4. Choose a session card and select Register.
+5. If you are not logged in yet, fill your first name and last name in the form.
+6. If you are under 18, enable the underage checkbox and set your age.
+7. Select Ok.
+8. Review your registration details in the confirmation dialog.
+9. Select Ok to confirm registration.
+10. Wait for the result message.
+
+Expected result:
+- You see Registration successfull.
+- The session card changes to a registered state.
+- Your name is shown in the Logged in alert.
+
+## Login With PIN
+1. On the trainee page, select Login.
+2. Enter your PIN code (4 to 6 digits).
+3. Select Verify.
+
+Expected result:
+- You see PIN verified succesfully.
+- You are shown as logged in.
+- Register PIN and Login buttons are disabled while logged in.
+
+## Register a New PIN (Trainee)
+1. On the trainee page, select Register PIN.
+2. Fill first name, last name, and PIN fields.
+3. If you are under 18, enable the underage option and set age.
+4. Select Register.
+
+Expected result:
+- You see PIN code registered successfully.
+- You are treated as logged in for registrations.
+
+## Other Useful Actions
+- Refresh data: reloads session list.
+- Log out: clears your logged-in trainee state and refreshes sessions.
+- Back to main: returns to the main view.
+
+## Error and Recovery
+- Invalid PIN. Try again.
+  - Check PIN length (4 to 6 digits) and retry.
+- Validation failed. Check input values.
+  - Verify name fields and underage age value.
+- Concurrent operation ongoing. Please try again.
+  - Wait a moment and retry.
+- Registration failed. Please try again.
+  - Refresh data and retry.
+
+## Notes About Session Cards
+- Session cards show session name and time.
+- Coach name is shown only for free/sparring sessions.
+- Camp instructor is shown for camp sessions.
+- A registered card shows a Done icon and Unregister label.
+- Current behavior: Unregister action is not active yet in trainee flow.
+
+## Quick Tips
+- Registering a PIN makes repeated registrations faster.
+- Keep your PIN private.
+- If the page seems outdated, use Refresh data before retrying actions.

--- a/user_manuals/trainee-manual.fi.md
+++ b/user_manuals/trainee-manual.fi.md
@@ -1,0 +1,73 @@
+# Harrastajan käyttöohje (suomi)
+
+## Tarkoitus
+Tämä ohje auttaa harrastajaa kirjautumaan ja ilmoittautumaan harjoituksiin.
+
+## Ennen aloittamista
+- Pääset sovelluksen etusivulle.
+- Tiedät omat nimitietosi.
+- Jos sinulla on PIN-koodi, pidä se valmiina.
+
+## Pääpolku: Ilmoittaudu harjoitukseen
+1. Avaa sovelluksen etusivu.
+2. Valitse Harrastajat.
+3. Odota, että harjoituslista latautuu.
+4. Valitse harjoituskortilta Ilmoittaudu.
+5. Jos et ole kirjautunut, täytä etu- ja sukunimi.
+6. Jos olet alle 18-vuotias, valitse alaikäinen ja aseta ikä.
+7. Valitse Ok.
+8. Tarkista tiedot vahvistusikkunassa.
+9. Valitse Ok vahvistaaksesi ilmoittautumisen.
+10. Odota tulosviesti.
+
+Odotettu tulos:
+- Näet viestin Ilmoittautuminen onnistui.
+- Harjoituskortti muuttuu ilmoittautuneeksi.
+- Nimesi näkyy Kirjautunut-ilmoituksessa.
+
+## Kirjaudu PIN-koodilla
+1. Valitse harrastajasivulla Kirjaudu.
+2. Syötä PIN-koodi (4-6 numeroa).
+3. Valitse Tarkista.
+
+Odotettu tulos:
+- Näet onnistumisviestin PIN-koodin tarkistuksesta.
+- Olet kirjautuneena.
+- Rekisteröi PIN- ja Kirjaudu-painikkeet poistuvat käytöstä kirjautumisen aikana.
+
+## Rekisteröi uusi PIN (harrastaja)
+1. Valitse harrastajasivulla Rekisteröi PIN.
+2. Täytä etunimi, sukunimi ja PIN-kentät.
+3. Jos olet alle 18-vuotias, valitse alaikäinen ja aseta ikä.
+4. Valitse Rekisteröi.
+
+Odotettu tulos:
+- Näet viestin PIN-koodi rekisteröity onnistuneesti.
+- Voit jatkaa ilmoittautumisia kirjautuneena.
+
+## Muut hyödylliset toiminnot
+- Päivitä tiedot: lataa harjoituslista uudelleen.
+- Kirjaudu ulos: tyhjentää kirjautumistiedot ja päivittää listan.
+- Takaisin etusivulle: palaa etusivulle.
+
+## Virheet ja toipuminen
+- Virheellinen PIN-koodi. Yritä uudelleen.
+  - Tarkista pituus (4-6 numeroa) ja yritä uudelleen.
+- Validointi epäonnistui. Tarkista syötteet.
+  - Tarkista nimi- ja ikätiedot.
+- Samanaikainen operaatio käynnissä. Yritä uudelleen.
+  - Odota hetki ja yritä uudelleen.
+- Ilmoittautuminen epäonnistui. Yritä uudelleen.
+  - Päivitä tiedot ja yritä uudelleen.
+
+## Huomiot harjoituskorteista
+- Kortti näyttää harjoituksen nimen ja ajan.
+- Valmentajan nimi näkyy vain vapaa/sparraus-harjoituksissa.
+- Leirin ohjaaja näkyy leiriharjoituksissa.
+- Ilmoittautunut kortti näyttää Done-kuvakkeen ja Peru ilmoittautuminen -tekstin.
+- Nykyinen toiminta: Peru ilmoittautuminen ei ole vielä käytössä harrastajavirrassa.
+
+## Pikaohjeet
+- PIN-koodin rekisteröinti nopeuttaa toistuvia ilmoittautumisia.
+- Pidä PIN-koodisi yksityisenä.
+- Jos näkymä näyttää vanhaa tietoa, käytä Päivitä tiedot.

--- a/user_stories/application/features/OQM-0021-create-user-manuals/OQM-0021-create-user-manuals.md
+++ b/user_stories/application/features/OQM-0021-create-user-manuals/OQM-0021-create-user-manuals.md
@@ -1,0 +1,91 @@
+**Title:**
+OQM-0021 Create User Manuals
+
+**Description:**
+Create clear end-user manuals for trainee and coach user paths in both English and Finnish. Manuals must focus on UI usage only and help first-time users complete key flows without technical support.
+
+**User Story:**
+As a trainee or coach, I want concise step-by-step usage instructions in my language so that I can use the application correctly without knowing implementation details.
+
+**Scope:**
+- Create a trainee manual in English and Finnish.
+- Create a coach manual in English and Finnish.
+- Use Markdown format and store manuals under root folder `user_manuals/`.
+- Cover only user-facing flows and visible UI behavior.
+
+**Out Of Scope:**
+- Backend architecture, API contracts, sheet schema, deployment, or any technical internals.
+- Developer setup instructions.
+
+**Preconditions:**
+- Root folder exists: `user_manuals/`.
+- Application flows referenced in manuals are already implemented in the UI.
+- All UI labels referenced in manuals match localized app text.
+
+**Deliverables:**
+- `user_manuals/trainee-manual.en.md`
+- `user_manuals/trainee-manual.fi.md`
+- `user_manuals/coach-manual.en.md`
+- `user_manuals/coach-manual.fi.md`
+
+**Manual Structure Requirements (all 4 manuals):**
+1. Short purpose section (who the manual is for).
+2. Prerequisites for user (what they need before starting).
+3. Step-by-step main usage flows with expected outcomes.
+4. Error and recovery section (what the user should do when an action fails).
+5. FAQ or quick tips section.
+6. Keep language non-technical and action-oriented.
+
+**Main Flow (Create Manuals):**
+1. Draft English versions first for trainee and coach.
+2. Verify flow coverage against current UI pages and dialogs.
+3. Add Finnish versions with matching structure and meaning.
+4. Review all four manuals for terminology consistency and clarity.
+5. Confirm each described step can be completed in the current UI.
+
+**Alternative Flows:**
+1. If a referenced UI flow is not yet implemented:
+    - Document only currently available user actions.
+    - Mark missing behavior in issue notes and exclude it from manuals.
+2. If EN/FI translation meaning diverges:
+    - Keep EN/FI section structure identical.
+    - Resolve wording mismatch before closing the issue.
+
+**Finalization Flow:**
+1. Validate file paths, naming, and Markdown readability.
+2. Peer-review manuals for language clarity and flow accuracy.
+3. Link manuals in PR description and this issue.
+
+**User Feedback Messages:**
+- No new runtime UI messages are introduced by this issue.
+- Manuals must include examples of existing user-visible messages where relevant (for example success, validation, and failure feedback) using plain-language explanation.
+
+**Test Cases:**
+- All four manual files exist in `user_manuals/` with correct filenames.
+- Each manual includes purpose, prerequisites, steps, error recovery, and tips sections.
+- A reviewer can follow each documented main flow in the UI without needing technical knowledge.
+- EN/FI versions for trainee manual contain equivalent content.
+- EN/FI versions for coach manual contain equivalent content.
+- No manual contains backend, API, sheet, or deployment implementation details.
+- Markdown renders correctly in GitHub preview.
+
+**Acceptance Criteria:**
+- Four manuals are created (trainee/coach x EN/FI) under `user_manuals/`.
+- Manuals are UI-focused, non-technical, and understandable for first-time users.
+- Documented steps match current application behavior.
+- EN/FI content pairs are semantically equivalent.
+- Manuals include guidance for common user errors and retries.
+- All placeholders are removed from this issue before completion.
+
+**Linked Files/Branches:**
+- `user_manuals/trainee-manual.en.md`
+- `user_manuals/trainee-manual.fi.md`
+- `user_manuals/coach-manual.en.md`
+- `user_manuals/coach-manual.fi.md`
+- Branch: `feature/oqm-0021-create-user-manuals`
+
+**References:**
+- `AGENTS.md`
+- `README.md`
+- `.github/instructions/copilot-instructions.md`
+- `.github/instructions/frontend.instructions.md`


### PR DESCRIPTION
## Summary
- Linked issue: #40
- User manuals drafted (EN + FI, trainee + coach)
- Created four manuals under `user_manuals\` folder:
    - trainee-manual.en.md
    - coach-manual.en.md
    - trainee-manual.fi.md
    - coach-manual.fi.md
- Copilot behavior configured for future manual upkeep
    - Added explicit repository instruction to create/update manuals whenever user-visible UI behavior changes.
    - Added PR review checklist item to verify manual updates are included.
    - Updated files:
        - copilot-instructions.md
        - review-checklist.instructions.md

## Checklist
- [ ] Tests added/updated and passing
- [ ] No secrets committed
- [ ] API contract adhered to
- [ ] Updated docs/skills if schema or flows changed
