### PR TITLE
feat: OQM-0023 enable coach login through trainee PIN verification for session registration

### DIFF
--- a/gas/Code.gs
+++ b/gas/Code.gs
@@ -355,27 +355,44 @@ function registerTraineePin_(payload) {
 }
 
 /**
- * Verify a trainee PIN code against the trainee_login sheet.
- * Returns the matching trainee's row data or null if no match found.
+ * Verify a trainee PIN code against trainee_login first, then coach_login as fallback.
+ * Returns trainee-shaped data from trainee_login when matched.
+ * If no trainee match exists but coach PIN matches, maps coach row to trainee shape
+ * (age is an empty string and alias is not included).
+ * Returns null if no match is found in either sheet.
  * Schema: id, firstname, lastname, age, pin, created_at, last_activity (columns A–G)
  * See SKILL.sheet-schema.md for full schema definition.
- * See SKILL.wire-react-to-gas.md for API contract (OQM-0016).
+ * See SKILL.wire-react-to-gas.md for API contract (OQM-0016, OQM-0023).
  */
 function verifyTraineePin_(payload) {
   if (!payload || !payload.pin) {
     throw new Error('Missing required fields: pin');
   }
-  const rows = getSheetData('trainee_login');
-  const row = rows.find(r => r[4] && String(r[4]) === String(payload.pin));
-  if (!row) return null;
+  const traineeRows = getSheetData('trainee_login');
+  const traineeRow = traineeRows.find(r => r[4] && String(r[4]) === String(payload.pin));
+  if (traineeRow) {
+    return {
+      id: String(traineeRow[0]),
+      firstname: String(traineeRow[1]),
+      lastname: String(traineeRow[2]),
+      age: String(traineeRow[3]),
+      pin: String(traineeRow[4]),
+      created_at: String(traineeRow[5]),
+      last_activity: String(traineeRow[6])
+    };
+  }
+
+  const coachRows = getSheetData('coach_login');
+  const coachRow = coachRows.find(r => r[4] && String(r[4]) === String(payload.pin));
+  if (!coachRow) return null;
   return {
-    id: String(row[0]),
-    firstname: String(row[1]),
-    lastname: String(row[2]),
-    age: String(row[3]),
-    pin: String(row[4]),
-    created_at: String(row[5]),
-    last_activity: String(row[6])
+    id: String(coachRow[0]),
+    firstname: String(coachRow[1]),
+    lastname: String(coachRow[2]),
+    age: '',
+    pin: String(coachRow[4]),
+    created_at: String(coachRow[5]),
+    last_activity: String(coachRow[6])
   };
 }
 

--- a/gas/__tests__/verifyTraineePin.test.js
+++ b/gas/__tests__/verifyTraineePin.test.js
@@ -1,0 +1,214 @@
+/**
+ * @copyright 2026 Jouni Sipola by OQM. All rights reserved.
+ * Permission granted for personal/internal use only. Commercial
+ * use prohibited except by copyright holder. See LICENSE for details.
+ */
+
+/**
+ * @description Backend unit tests for verifyTraineePin_ fallback behavior (OQM-0023).
+ * @see skills/SKILL.wire-react-to-gas.md
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function toPlain(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function createSandbox() {
+  const sandbox = {
+    console,
+    PropertiesService: {
+      getScriptProperties() {
+        return {
+          getProperty() {
+            return 'test';
+          },
+        };
+      },
+    },
+    ContentService: {
+      MimeType: { JSON: 'application/json' },
+      createTextOutput(payload) {
+        return {
+          payload,
+          setMimeType() {
+            return this;
+          },
+        };
+      },
+    },
+    SpreadsheetApp: {
+      openById() {
+        return {
+          getSheetByName() {
+            return null;
+          },
+        };
+      },
+    },
+    Session: {
+      getScriptTimeZone() {
+        return 'UTC';
+      },
+    },
+    Utilities: {
+      getUuid() {
+        return 'uuid';
+      },
+      formatDate(date) {
+        if (!(date instanceof Date)) return String(date || '');
+        return date.toISOString();
+      },
+    },
+    LockService: {
+      getScriptLock() {
+        return {
+          tryLock() {
+            return true;
+          },
+          releaseLock() {},
+        };
+      },
+    },
+    Date,
+    JSON,
+    String,
+    Number,
+    Boolean,
+    Object,
+    Array,
+    Math,
+    Error,
+  };
+
+  vm.createContext(sandbox);
+  const codePath = path.join(__dirname, '..', 'Code.gs');
+  const code = fs.readFileSync(codePath, 'utf8');
+  vm.runInContext(code, sandbox, { filename: 'Code.gs' });
+  return sandbox;
+}
+
+test('verifyTraineePin_ returns trainee row when pin exists in trainee_login', () => {
+  const sandbox = createSandbox();
+  sandbox.getSheetData = (sheetName) => {
+    if (sheetName === 'trainee_login') {
+      return [[
+        'trainee-1',
+        'Trainee',
+        'User',
+        '14',
+        '1111',
+        '2026-01-01T00:00:00.000Z',
+        '2026-02-01T00:00:00.000Z',
+      ]];
+    }
+    if (sheetName === 'coach_login') {
+      return [[
+        'coach-1',
+        'Coach',
+        'User',
+        'Alias',
+        '1111',
+        '2026-01-01T00:00:00.000Z',
+        '2026-02-01T00:00:00.000Z',
+      ]];
+    }
+    return [];
+  };
+
+  const result = sandbox.verifyTraineePin_({ pin: '1111' });
+
+  assert.deepEqual(toPlain(result), {
+    id: 'trainee-1',
+    firstname: 'Trainee',
+    lastname: 'User',
+    age: '14',
+    pin: '1111',
+    created_at: '2026-01-01T00:00:00.000Z',
+    last_activity: '2026-02-01T00:00:00.000Z',
+  });
+});
+
+test('verifyTraineePin_ falls back to coach_login and maps coach to trainee shape', () => {
+  const sandbox = createSandbox();
+  sandbox.getSheetData = (sheetName) => {
+    if (sheetName === 'trainee_login') return [];
+    if (sheetName === 'coach_login') {
+      return [[
+        'coach-9',
+        'Mika',
+        'Virtanen',
+        'Mikke',
+        '2222',
+        '2026-01-10T08:00:00.000Z',
+        '2026-02-11T09:30:00.000Z',
+      ]];
+    }
+    return [];
+  };
+
+  const result = sandbox.verifyTraineePin_({ pin: '2222' });
+
+  assert.deepEqual(toPlain(result), {
+    id: 'coach-9',
+    firstname: 'Mika',
+    lastname: 'Virtanen',
+    age: '',
+    pin: '2222',
+    created_at: '2026-01-10T08:00:00.000Z',
+    last_activity: '2026-02-11T09:30:00.000Z',
+  });
+  assert.equal(Object.prototype.hasOwnProperty.call(result, 'alias'), false);
+});
+
+test('verifyTraineePin_ returns null when pin is in neither trainee_login nor coach_login', () => {
+  const sandbox = createSandbox();
+  sandbox.getSheetData = () => [];
+
+  const result = sandbox.verifyTraineePin_({ pin: '9999' });
+
+  assert.equal(result, null);
+});
+
+test('verifyTraineePin_ keeps validation behavior for missing pin', () => {
+  const sandbox = createSandbox();
+
+  assert.throws(
+    () => sandbox.verifyTraineePin_({}),
+    /Missing required fields: pin/
+  );
+});
+
+test('verifyCoachPin_ behavior remains unchanged', () => {
+  const sandbox = createSandbox();
+  sandbox.getSheetData = (sheetName) => {
+    if (sheetName === 'coach_login') {
+      return [[
+        'coach-2',
+        'Anna',
+        'Korhonen',
+        'AK',
+        '3333',
+        '2026-01-01T00:00:00.000Z',
+        '2026-03-01T00:00:00.000Z',
+      ]];
+    }
+    return [];
+  };
+
+  const result = sandbox.verifyCoachPin_({ pin: '3333' });
+
+  assert.deepEqual(toPlain(result), {
+    id: 'coach-2',
+    firstname: 'Anna',
+    lastname: 'Korhonen',
+    alias: 'AK',
+    pin: '3333',
+    created_at: '2026-01-01T00:00:00.000Z',
+    last_activity: '2026-03-01T00:00:00.000Z',
+  });
+});

--- a/skills/SKILL.wire-react-to-gas.md
+++ b/skills/SKILL.wire-react-to-gas.md
@@ -253,10 +253,23 @@ export async function registerTraineePin(data: RegisterTraineePinData): Promise<
 { "ok": false, "error": "no_match_found" }
 ```
 
+### Fallback behavior (OQM-0023)
+- Backend checks `trainee_login` first.
+- If no trainee match exists, backend checks `coach_login`.
+- If coach PIN matches, backend returns trainee-shaped `data` for compatibility:
+  - `id <- coach_login.id`
+  - `firstname <- coach_login.firstname`
+  - `lastname <- coach_login.lastname`
+  - `age <- ""` (empty string)
+  - `pin <- coach_login.pin`
+  - `created_at <- coach_login.created_at`
+  - `last_activity <- coach_login.last_activity`
+- `alias` is intentionally not included in `verifyTraineePin` response.
+
 ### Error cases
 | Error            | Meaning                                      |
 |------------------|----------------------------------------------|
-| `no_match_found` | PIN not found in `trainee_login` sheet       |
+| `no_match_found` | PIN not found in either `trainee_login` or `coach_login` |
 | `Unauthorized`   | Invalid or missing API token                 |
 | `Missing required fields: pin` | Payload validation failure     |
 
@@ -264,8 +277,9 @@ export async function registerTraineePin(data: RegisterTraineePinData): Promise<
 ```ts
 /**
  * Verify a trainee PIN code against the GAS backend.
- * Returns TraineeData on success.
- * Throws Error('no_match_found') if PIN does not match any trainee.
+ * Returns trainee-shaped TraineeData on success.
+ * Backend checks trainee_login first and then coach_login as fallback (OQM-0023).
+ * Throws Error('no_match_found') if PIN does not match any trainee or coach.
  * Throws other Errors on network/service failures.
  */
 export async function verifyTraineePin(pin: string): Promise<TraineeData> {

--- a/user_manuals/coach-manual.en.md
+++ b/user_manuals/coach-manual.en.md
@@ -61,6 +61,16 @@ Expected result:
 - Refresh data: reloads the current session list.
 - Back to main: exits coach page.
 
+## Register Yourself as a Trainee (Using Coach PIN)
+1. Return to the main view and select Trainees.
+2. Select Login.
+3. Enter your coach PIN and select Verify.
+4. Register for a trainee-side session normally.
+
+Expected result:
+- Coach PIN is accepted in trainee login.
+- You can proceed with trainee-side session registration without creating a separate trainee PIN.
+
 ## Error and Recovery
 - Invalid PIN. Try again.
   - Re-enter PIN and verify.

--- a/user_manuals/coach-manual.fi.md
+++ b/user_manuals/coach-manual.fi.md
@@ -61,6 +61,16 @@ Odotettu tulos:
 - Päivitä tiedot: lataa harjoituslista uudelleen.
 - Takaisin etusivulle: poistu valmentajasivulta.
 
+## Ilmoittaudu harrastajaksi valmentajan PIN-koodilla
+1. Palaa etusivulle ja valitse Harrastajat.
+2. Valitse Kirjaudu.
+3. Syötä valmentajan PIN-koodisi ja valitse Tarkista.
+4. Ilmoittaudu harrastajapuolen harjoitukseen normaalisti.
+
+Odotettu tulos:
+- Valmentajan PIN hyväksytään harrastajakirjautumisessa.
+- Voit jatkaa harrastajapuolen ilmoittautumista ilman erillistä harrastajan PIN-koodia.
+
 ## Virheet ja toipuminen
 - Virheellinen PIN-koodi. Yritä uudelleen.
   - Syötä PIN uudelleen ja tarkista.

--- a/user_manuals/trainee-manual.en.md
+++ b/user_manuals/trainee-manual.en.md
@@ -30,6 +30,9 @@ Expected result:
 2. Enter your PIN code (4 to 6 digits).
 3. Select Verify.
 
+Note:
+- Coaches can also use their existing coach PIN in this same login flow when registering as a trainee.
+
 Expected result:
 - You see PIN verified succesfully.
 - You are shown as logged in.

--- a/user_manuals/trainee-manual.fi.md
+++ b/user_manuals/trainee-manual.fi.md
@@ -30,6 +30,9 @@ Odotettu tulos:
 2. Syötä PIN-koodi (4-6 numeroa).
 3. Valitse Tarkista.
 
+Huom:
+- Valmentaja voi käyttää tässä samassa kirjautumisessa myös omaa valmentajan PIN-koodiaan, kun hän ilmoittautuu harrastajana.
+
 Odotettu tulos:
 - Näet onnistumisviestin PIN-koodin tarkistuksesta.
 - Olet kirjautuneena.

--- a/user_stories/coach/features/OQM-0023-coach-registration-for-a-training-session-as-a-trainee/OQM-0023-coach-registration-for-a-training-session-as-a-trainee.md
+++ b/user_stories/coach/features/OQM-0023-coach-registration-for-a-training-session-as-a-trainee/OQM-0023-coach-registration-for-a-training-session-as-a-trainee.md
@@ -1,0 +1,86 @@
+**Title:**
+OQM-0023 Enable Coach Login Through verifyTraineePin for Trainee Session Registration
+
+**Description:**
+Allow a coach to authenticate in the trainee flow using an existing coach PIN so coaches can register themselves into trainee-side training sessions without creating a separate trainee PIN.
+
+**User Story:**
+As a coach, I want to log in through the trainee PIN verification flow, so that I can register for sessions where I participate as a trainee.
+
+**Scope:**
+- Backend only: update GAS verifyTraineePin behavior.
+- Keep existing request and response envelope contract unchanged: { ok: true, data } | { ok: false, error }.
+- verifyTraineePin checks trainee_login first; if no match, check coach_login.
+- If PIN is found in coach_login, map coach row into trainee-shaped response data:
+  - id <- coach_login.id
+  - firstname <- coach_login.firstname
+  - lastname <- coach_login.lastname
+  - age <- empty string (coach sheet has no age column)
+  - pin <- coach_login.pin
+  - created_at <- coach_login.created_at
+  - last_activity <- coach_login.last_activity
+- Do not include alias in verifyTraineePin response (response remains trainee-shaped).
+- No UI behavior changes required in this issue.
+
+**Out of Scope:**
+- Changes to frontend components, button states, or translations.
+- Schema changes to Google Sheets.
+- New API routes or payload fields.
+
+**Preconditions:**
+- GAS route verifyTraineePin is already wired and used by trainee login flow.
+- Sheets coach_login and trainee_login follow documented schema.
+- API token validation remains enforced.
+
+**Main Flow (Verify PIN):**
+1. Client sends POST request with route verifyTraineePin and payload { pin }.
+2. Backend validates token and required payload field pin.
+3. Backend looks up pin in trainee_login.
+4. If trainee match exists, return existing trainee response behavior unchanged.
+5. If no trainee match exists, backend looks up pin in coach_login.
+6. If coach match exists, backend returns ok: true with trainee-shaped data mapped from coach row.
+7. Existing frontend treats response as successful trainee verification.
+
+**Alternative Flows:**
+1. PIN does not exist in trainee_login or coach_login:
+    - Return { ok: false, error: "no_match_found" }.
+2. Missing or invalid token:
+    - Return unauthorized error according to current API behavior.
+3. Missing pin in payload:
+    - Return validation error according to current API behavior.
+
+**Post-Verification Flow (unchanged):**
+1. Existing trainee page login success handling continues without frontend changes.
+2. User can proceed to trainee session registration using the verified identity.
+
+**User Feedback Messages:**
+- No new messages in this issue.
+- Existing trainee login success/error messages remain unchanged.
+
+**Test Cases:**
+- Unit test: verifyTraineePin returns trainee data when PIN exists in trainee_login.
+- Unit test: verifyTraineePin returns mapped trainee-shaped data when PIN exists only in coach_login.
+- Unit test: mapped coach result sets age to empty string and does not expose alias.
+- Unit test: verifyTraineePin returns no_match_found when PIN exists in neither sheet.
+- Unit test: verifyTraineePin keeps existing token and payload validation behavior.
+- Regression test: existing verifyCoachPin behavior remains unchanged.
+
+**Acceptance Criteria:**
+- verifyTraineePin checks trainee_login first and coach_login second.
+- When matched in coach_login, response is ok: true and data shape matches trainee contract.
+- Response mapping from coach_login fields is correct and deterministic.
+- age is returned as empty string for coach-based matches.
+- alias is not present in verifyTraineePin success payload.
+- Existing verifyTraineePin behavior for trainee matches is unchanged.
+- Existing no_match_found, unauthorized, and validation error behavior is unchanged.
+- Automated tests cover trainee match, coach fallback match, and not-found cases.
+
+**Linked Files/Branches:**
+- [Code.gs](gas/Code.gs)
+- [OQM-0023-coach-registration-for-a-training-session-as-a-trainee.md](user_stories/coach/features/OQM-0023-coach-registration-for-a-training-session-as-a-trainee/OQM-0023-coach-registration-for-a-training-session-as-a-trainee.md)
+- Suggested branch: feature/oqm-0023-coach-as-trainee-verification
+
+**References:**
+- [SKILL.wire-react-to-gas.md](skills/SKILL.wire-react-to-gas.md)
+- [SKILL.sheet-schema.md](skills/SKILL.sheet-schema.md)
+- [backend.instructions.md](.github/instructions/backend.instructions.md)

--- a/user_stories/coach/features/OQM-0023-coach-registration-for-a-training-session-as-a-trainee/prompt.md
+++ b/user_stories/coach/features/OQM-0023-coach-registration-for-a-training-session-as-a-trainee/prompt.md
@@ -1,0 +1,9 @@
+Implement the feature described in GitHub issue #44:
+- Follow [SKILL.wire-react-to-gas.md](http://_vscodecontentref_/0) for API contract
+- Use [SKILL.sheet-schema.md](http://_vscodecontentref_/1) for data structure
+- Apply all relevant instructions from 
+    - [copilot-instructions.md](http://_vscodecontentref_/2)
+    - [frontend.instructions.md](http://_vscodecontentref_/3)
+    - [backend.instructions.md](http://_vscodecontentref_/4)    
+- Use TDD and update documentation
+- Update user manual(s) per copilot instructions

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -179,7 +179,7 @@ export default function App() {
     <ThemeProvider theme={theme}>
       <CssBaseline />
       <Toaster position="top-center" />
-      <BrowserRouter>
+      <BrowserRouter future={{ v7_relativeSplatPath: true }}>
         <Routes>
           <Route
             path="/"

--- a/web/src/features/trainee/api/trainee.api.ts
+++ b/web/src/features/trainee/api/trainee.api.ts
@@ -45,8 +45,9 @@ export async function registerTraineePin(data: RegisterTraineePinData): Promise<
 /**
  * Verify a trainee PIN code against the GAS backend.
  * POST { route: "verifyTraineePin", payload: { pin }, token }
- * Returns trainee data on success.
- * Throws Error('no_match_found') if the PIN does not match any trainee.
+ * Returns trainee-shaped data on success.
+ * Backend checks trainee_login first and then coach_login as fallback (OQM-0023).
+ * Throws Error('no_match_found') if the PIN does not match any trainee or coach.
  * Throws other Errors for network/service failures.
  * @see skills/SKILL.wire-react-to-gas.md
  */


### PR DESCRIPTION

## Linked Issue
closes: #44

## Summary
This PR enables coaches to authenticate through the trainee PIN verification flow so they can register for trainee-side sessions without creating a separate trainee PIN.

### What Changed
- Updated backend verifyTraineePin behavior in Code.gs:
    - Check trainee_login first (existing behavior preserved).
    - If no trainee match is found, check coach_login.
    - When coach PIN matches, return trainee-shaped data:
        - id from coach row id
        - firstname from coach firstname
        - lastname from coach lastname
        - age as empty string
        - pin from coach pin
        - created_at from coach created_at
        - last_activity from coach last_activity
        - alias is not returned in verifyTraineePin response.
        - No new routes, payload fields, or schema changes.
        
### Contract Compliance
- Response envelope remains unchanged:
    - success: ok true with data
    - failure: ok false with error
    - no_match_found behavior is preserved when PIN is in neither trainee_login nor coach_login.
    - Token and payload validation behavior is unchanged.

### Documentation Updates
- Updated API contract in SKILL.wire-react-to-gas.md for OQM-0023 fallback behavior.
- Updated trainee API doc comments in trainee.api.ts
- Updated user manuals for user-visible behavior:
        - trainee-manual.en.md
        - trainee-manual.fi.md
        - coach-manual.en.md
        - coach-manual.fi.md

### Out of Scope
- No UI flow changes.
- No localization key changes.
- No Google Sheet schema changes.
- No new backend routes.

## Review Checklist
- [ ] Documentation and skill updates included.
- [ ] User manuals updated in English and Finnish.
- [ ] Contract remains compatible with existing frontend.
- [ ] Automated tests cover trainee match, coach fallback, and not-found scenarios.
