### PR TITLE
feat(coach): OQM-0027 group CoachPage sessions into weekly tabs with current-week default

### DIFF
--- a/user_manuals/coach-manual.en.md
+++ b/user_manuals/coach-manual.en.md
@@ -32,7 +32,17 @@ Expected result:
 
 Expected result:
 - You enter Coach Quick Registration.
-- Session cards are shown in date groups.
+- Session cards are shown under week tabs.
+
+## Browse Sessions by Week Tabs
+1. Open Coach Quick Registration.
+2. Use the week tabs above the session list.
+3. By default, the current calendar week tab is selected.
+4. Select another week tab to view that week's sessions.
+
+Expected result:
+- Only sessions from the selected week are shown.
+- Sessions remain grouped by day inside the selected week.
 
 ## Register as Coach for a Session
 1. On Coach Quick Registration, find a session card.

--- a/user_manuals/coach-manual.fi.md
+++ b/user_manuals/coach-manual.fi.md
@@ -32,7 +32,17 @@ Odotettu tulos:
 
 Odotettu tulos:
 - Siirryt valmentajan pikailmoittautumiseen.
-- Harjoituskortit näkyvät päivittäin ryhmiteltyinä.
+- Harjoituskortit näkyvät viikkovälilehtien alla.
+
+## Selaa harjoituksia viikkovälilehdillä
+1. Avaa valmentajan pikailmoittautuminen.
+2. Käytä harjoituslistan yläpuolella olevia viikkovälilehtiä.
+3. Nykyinen kalenteriviikko valitaan oletuksena.
+4. Valitse toinen viikkovälilehti nähdäksesi kyseisen viikon harjoitukset.
+
+Odotettu tulos:
+- Näet vain valitun viikon harjoitukset.
+- Harjoitukset pysyvät päivittäin ryhmiteltyinä valitun viikon sisällä.
 
 ## Ilmoittaudu valmentajaksi harjoitukseen
 1. Etsi valmentajasivulta harjoituskortti.

--- a/user_stories/coach/features/OQM-0027-show-coachpage-training-cards-in-tabs/OQM-0027-show-coachpage-training-cards-in-tabs.md
+++ b/user_stories/coach/features/OQM-0027-show-coachpage-training-cards-in-tabs/OQM-0027-show-coachpage-training-cards-in-tabs.md
@@ -1,0 +1,59 @@
+# Title
+OQM-0027: Show CoachPage session cards in weekly tabs (current week by default)
+
+## Summary
+Coaches need faster navigation through the 21-day session window on Coach Quick Registration.
+Replace the current flat date-grouped rendering with weekly tabs so coaches can view one calendar week (Mon-Sun) at a time. The current calendar week must be selected by default.
+
+## Problem
+The current session list can be hard to scan when many days are shown at once. Coaches requested week-level navigation to reduce cognitive load and speed up session selection.
+
+## Scope
+- Add MUI Tabs and Tab to Coach Quick Registration page.
+- Group existing date groups into calendar week buckets (Mon-Sun).
+- Default selected tab to current calendar week if present; otherwise first available week.
+- Keep existing SessionCard behavior and register/remove/sparring flows unchanged.
+- Add localized week tab labels (EN/FI).
+- Update coach user manuals (EN/FI) for the new navigation behavior.
+- Add frontend tests for tab rendering, default selection, and tab switching behavior.
+
+## Out of scope
+- Backend or GAS route changes.
+- Trainee page UI parity changes.
+- Broad refactor of shared date utilities.
+
+## User flow
+1. Coach logs in and opens Coach Quick Registration.
+2. Coach sees week tabs above sessions.
+3. Current calendar week is selected by default.
+4. Coach switches tabs to view another week.
+5. Inside each tab, sessions remain grouped by date and rendered as SessionCards.
+6. Coach can still Register, Remove, Refresh, and use Free/sparring flow as before.
+
+## Acceptance criteria
+1. Coach Quick Registration shows week tabs when sessions are available.
+2. Tabs represent calendar weeks from Monday to Sunday.
+3. Current calendar week is selected by default when available.
+4. If current week is not present, first available week is selected.
+5. Selecting a week tab only shows sessions from that week.
+6. Sessions within the selected week remain grouped by day.
+7. Existing Register/Remove/Manual/Sparring/Refresh behavior remains unchanged.
+8. New week tab labels are localized in English and Finnish.
+9. Coach manuals in English and Finnish describe weekly tab usage.
+10. Tests cover:
+    - multi-week tab rendering
+    - default current-week selection
+    - tab switch visibility behavior
+
+## Concrete test cases
+1. Given sessions in two different weeks, when CoachPage loads, then two tabs are rendered.
+2. Given sessions in current week and next week, when CoachPage loads, then current week session is visible and next week session is hidden.
+3. Given two week tabs, when user clicks second tab, then second-week session is visible and current-week session is hidden.
+4. Given only one week in data, when CoachPage loads, then one tab is rendered and sessions are shown normally.
+5. Given no sessions, when CoachPage loads, then no-sessions state is shown and tab container is not shown.
+
+## Definition of done
+- [] Feature implemented and tests green.
+- [] Localization updated in EN/FI locale files.
+- [] User manuals updated in EN/FI.
+- [] PR includes manual impact and test evidence.

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -141,6 +141,8 @@
   "coachQuickRegistration.sessionDateLabel": "Date",
   "coachQuickRegistration.sessionTimeLabel": "Time",
   "coachQuickRegistration.coachNameLabel": "Coach",
+  "coachQuickRegistration.weekTabLabel": "Week {{start}} - {{end}}",
+  "coachQuickRegistration.weekTabsAriaLabel": "Session weeks",
   "coachQuickRegistration.registrationOngoing": "Registration ongoing. Please wait.",
   "coachQuickRegistration.registrationSuccess": "Registration successful!",
   "coachQuickRegistration.registrationFailed": "Registration failed. Please try again.",

--- a/web/src/locales/fi.json
+++ b/web/src/locales/fi.json
@@ -141,6 +141,8 @@
   "coachQuickRegistration.sessionDateLabel": "P\u00e4iv\u00e4m\u00e4\u00e4r\u00e4",
   "coachQuickRegistration.sessionTimeLabel": "Aika",
   "coachQuickRegistration.coachNameLabel": "Valmentaja",
+  "coachQuickRegistration.weekTabLabel": "Viikko {{start}} - {{end}}",
+  "coachQuickRegistration.weekTabsAriaLabel": "Harjoitusviikot",
   "coachQuickRegistration.registrationOngoing": "Ilmoittautuminen k\u00e4ynniss\u00e4. Odota.",
   "coachQuickRegistration.registrationSuccess": "Ilmoittautuminen onnistui!",
   "coachQuickRegistration.registrationFailed": "Ilmoittautuminen ep\u00e4onnistui. Yrit\u00e4 uudelleen.",

--- a/web/src/pages/Coach/CoachPage.tsx
+++ b/web/src/pages/Coach/CoachPage.tsx
@@ -25,6 +25,8 @@ import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Container from '@mui/material/Container';
 import Stack from '@mui/material/Stack';
+import Tab from '@mui/material/Tab';
+import Tabs from '@mui/material/Tabs';
 import Typography from '@mui/material/Typography';
 import { LoadingOverlay } from '../../shared/components/LoadingOverlay/LoadingOverlay';
 import { SessionCard } from '../../features/coach/components/SessionCard';
@@ -52,6 +54,44 @@ function formatDateLabel(dateStr: string, locale: string): string {
   return `${weekday} ${String(day).padStart(2, '0')}.${String(month).padStart(2, '0')}.${year}`;
 }
 
+function toYmd(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function parseYmd(dateStr: string): Date {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  return new Date(year, month - 1, day);
+}
+
+function getWeekStartYmd(dateStr: string): string {
+  const date = parseYmd(dateStr);
+  const day = date.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  date.setDate(date.getDate() + diff);
+  return toYmd(date);
+}
+
+function addDaysToYmd(dateStr: string, daysToAdd: number): string {
+  const date = parseYmd(dateStr);
+  date.setDate(date.getDate() + daysToAdd);
+  return toYmd(date);
+}
+
+function formatWeekTabDate(dateStr: string): string {
+  const [, month, day] = dateStr.split('-');
+  return `${day}.${month}`;
+}
+
+interface WeekGroup {
+  weekKey: string;
+  weekStart: string;
+  weekEnd: string;
+  dates: Array<[string, SessionItem[]]>;
+}
+
 /** Coach Quick Registration page displaying a 21-day window of sessions grouped by date. */
 export function CoachPage({ onBack, coachData, sessionToken }: CoachPageProps) {
   const { t, i18n } = useTranslation();
@@ -65,6 +105,7 @@ export function CoachPage({ onBack, coachData, sessionToken }: CoachPageProps) {
   const [sparringDialogOpen, setSparringDialogOpen] = useState(false);
   const [sparringDialogData, setSparringDialogData] = useState<{ firstname: string; lastname: string } | undefined>(undefined);
   const [selectedSession, setSelectedSession] = useState<SessionItem | null>(null);
+  const [activeWeekTab, setActiveWeekTab] = useState('');
   // Temporary CoachData built from manual name entry or PIN registration (OQM-0010).
   const [pendingCoachData, setPendingCoachData] = useState<CoachData | undefined>(undefined);
 
@@ -79,7 +120,7 @@ export function CoachPage({ onBack, coachData, sessionToken }: CoachPageProps) {
     } finally {
       setLoading(false);
     }
-  }, [t]);
+  }, [sessionToken, t]);
 
   useEffect(() => {
     fetchSessions();
@@ -94,6 +135,43 @@ export function CoachPage({ onBack, coachData, sessionToken }: CoachPageProps) {
     }
     return map;
   }, [sessions]);
+
+  /** Group already date-grouped sessions by calendar week (Mon-Sun). */
+  const sessionsByWeek = useMemo(() => {
+    const weekMap = new Map<string, WeekGroup>();
+    const dateEntries = Array.from(sessionsByDate.entries()).sort(([a], [b]) => a.localeCompare(b));
+
+    for (const [date, dateSessions] of dateEntries) {
+      const weekKey = getWeekStartYmd(date);
+      if (!weekMap.has(weekKey)) {
+        weekMap.set(weekKey, {
+          weekKey,
+          weekStart: weekKey,
+          weekEnd: addDaysToYmd(weekKey, 6),
+          dates: [],
+        });
+      }
+      weekMap.get(weekKey)!.dates.push([date, dateSessions]);
+    }
+
+    return weekMap;
+  }, [sessionsByDate]);
+
+  const weekTabs = useMemo(() => Array.from(sessionsByWeek.values()), [sessionsByWeek]);
+
+  useEffect(() => {
+    if (weekTabs.length === 0) {
+      if (activeWeekTab !== '') setActiveWeekTab('');
+      return;
+    }
+
+    const activeExists = weekTabs.some(week => week.weekKey === activeWeekTab);
+    if (activeExists) return;
+
+    const currentWeekKey = getWeekStartYmd(toYmd(new Date()));
+    const defaultWeek = weekTabs.find(week => week.weekKey === currentWeekKey) ?? weekTabs[0];
+    setActiveWeekTab(defaultWeek.weekKey);
+  }, [activeWeekTab, weekTabs]);
 
   const loggedInLabel = coachData?.alias
     ? t('coachQuickRegistration.loggedInAs', { name: coachData.alias })
@@ -279,26 +357,57 @@ export function CoachPage({ onBack, coachData, sessionToken }: CoachPageProps) {
         </Card>
       )}
 
-      {Array.from(sessionsByDate.entries()).map(([date, dateSessions]) => (
-        <Card key={date} sx={{ mb: 3, borderRadius: 3 }}>
-          <CardContent>
-          <Typography variant="subtitle1" fontWeight="bold" sx={{ mb: 1 }}>
-            {formatDateLabel(date, i18n.language)}
-          </Typography>
-          <Box sx={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center', gap: 2 }}>
-            {dateSessions.map((session) => (
-              <SessionCard
-                key={session.id}
-                session={session}
-                onRegister={handleRegister}
-                onRemove={handleRemove}
-                cardStyle={{ width: '340px', height: '120px', display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}
-              />
-            ))}
-          </Box>
+      {!loading && !error && weekTabs.length > 0 && (
+        <Card sx={{ mb: 2, borderRadius: 3 }}>
+          <CardContent sx={{ pb: 1 }}>
+            <Tabs
+              value={activeWeekTab || false}
+              onChange={(_event, value: string) => setActiveWeekTab(value)}
+              variant={weekTabs.length <= 3 ? 'standard' : 'scrollable'}
+              centered={weekTabs.length <= 3}
+              scrollButtons={weekTabs.length <= 3 ? false : 'auto'}
+              allowScrollButtonsMobile
+              aria-label={t('coachQuickRegistration.weekTabsAriaLabel')}
+            >
+              {weekTabs.map(week => (
+                <Tab
+                  key={week.weekKey}
+                  value={week.weekKey}
+                  label={t('coachQuickRegistration.weekTabLabel', {
+                    start: formatWeekTabDate(week.weekStart),
+                    end: formatWeekTabDate(week.weekEnd),
+                  })}
+                />
+              ))}
+            </Tabs>
           </CardContent>
         </Card>
-      ))}
+      )}
+
+      {weekTabs
+        .filter(week => week.weekKey === activeWeekTab)
+        .map(week =>
+          week.dates.map(([date, dateSessions]) => (
+            <Card key={date} sx={{ mb: 3, borderRadius: 3 }}>
+              <CardContent>
+                <Typography variant="subtitle1" fontWeight="bold" sx={{ mb: 1 }}>
+                  {formatDateLabel(date, i18n.language)}
+                </Typography>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center', gap: 2 }}>
+                  {dateSessions.map(session => (
+                    <SessionCard
+                      key={session.id}
+                      session={session}
+                      onRegister={handleRegister}
+                      onRemove={handleRemove}
+                      cardStyle={{ width: '340px', height: '120px', display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}
+                    />
+                  ))}
+                </Box>
+              </CardContent>
+            </Card>
+          ))
+        )}
 
         <ConfirmCoachRegistrationDialog
         open={confirmRegisterOpen}

--- a/web/src/pages/Coach/__tests__/CoachPage.test.tsx
+++ b/web/src/pages/Coach/__tests__/CoachPage.test.tsx
@@ -64,6 +64,49 @@ const mockSession: SessionItem = {
   is_free_sparring: false,
 };
 
+function toYmd(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function getMonday(date: Date): Date {
+  const copy = new Date(date);
+  const day = copy.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  copy.setDate(copy.getDate() + diff);
+  copy.setHours(0, 0, 0, 0);
+  return copy;
+}
+
+function addDays(date: Date, days: number): Date {
+  const copy = new Date(date);
+  copy.setDate(copy.getDate() + days);
+  return copy;
+}
+
+function buildMultiWeekSessions(): [SessionItem, SessionItem] {
+  const monday = getMonday(new Date());
+  const currentWeekDate = toYmd(addDays(monday, 2));
+  const nextWeekDate = toYmd(addDays(monday, 8));
+
+  return [
+    {
+      ...mockSession,
+      id: 'ws-current-week',
+      session_type: 'Current Week Session',
+      date: currentWeekDate,
+    },
+    {
+      ...mockSession,
+      id: 'ws-next-week',
+      session_type: 'Next Week Session',
+      date: nextWeekDate,
+    },
+  ];
+}
+
 describe('CoachPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -127,6 +170,48 @@ describe('CoachPage', () => {
     render(<CoachPage onBack={vi.fn()} />);
     await waitFor(() => {
       expect(screen.getByText('Kickboxing')).toBeInTheDocument();
+    });
+  });
+
+  it('renders week tabs when sessions span multiple calendar weeks', async () => {
+    const [currentWeekSession, nextWeekSession] = buildMultiWeekSessions();
+    mockGetCoachSessions.mockResolvedValue([currentWeekSession, nextWeekSession]);
+    render(<CoachPage onBack={vi.fn()} />);
+
+    await waitFor(() => {
+      const tabs = screen.getAllByRole('tab');
+      expect(tabs).toHaveLength(2);
+    });
+  });
+
+  it('selects current week tab by default', async () => {
+    const [currentWeekSession, nextWeekSession] = buildMultiWeekSessions();
+    mockGetCoachSessions.mockResolvedValue([currentWeekSession, nextWeekSession]);
+    render(<CoachPage onBack={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Current Week Session')).toBeInTheDocument();
+      expect(screen.queryByText('Next Week Session')).not.toBeInTheDocument();
+    });
+  });
+
+  it('switches visible sessions when another week tab is selected', async () => {
+    const [currentWeekSession, nextWeekSession] = buildMultiWeekSessions();
+    const user = userEvent.setup();
+    mockGetCoachSessions.mockResolvedValue([currentWeekSession, nextWeekSession]);
+    render(<CoachPage onBack={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Current Week Session')).toBeInTheDocument();
+      expect(screen.queryByText('Next Week Session')).not.toBeInTheDocument();
+    });
+
+    const tabs = screen.getAllByRole('tab');
+    await user.click(tabs[1]);
+
+    await waitFor(() => {
+      expect(screen.getByText('Next Week Session')).toBeInTheDocument();
+      expect(screen.queryByText('Current Week Session')).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION

# Title
feat(coach): OQM-0027 group CoachPage sessions into weekly tabs with current-week default

## Summary
This PR adds weekly tab navigation to Coach Quick Registration so coaches can browse sessions one calendar week at a time. The current week is selected by default, while day-level grouping and existing registration/removal flows remain intact.

## Linked issue
#52 

## What changed
- Updated Coach page to:
    - group sessions by calendar week (Mon-Sun)
    - render MUI Tabs/Tab for week navigation
    - default to current week tab when available, otherwise first available week
    - keep SessionCard rendering grouped by date within selected week
- Added localization keys:
    - coachQuickRegistration.weekTabLabel
    - coachQuickRegistration.weekTabsAriaLabel
- Added tests for:
    - rendering multiple week tabs
    - current-week default selection
    - switching tabs updates visible sessions
- Updated user manuals:
    - English coach manual
    - Finnish coach manual
    - Files changed

## Testing
Ran: npm test -- src/pages/Coach/tests/CoachPage.test.tsx
Result: 24 passed, 0 failed

## Checklist
- [x] Documentation updated (manuals)
- [x]  User manuals updated for user-visible changes
- [x]  Test coverage for changed behavior
- [x]  Contract compliance preserved (no backend contract changes)