### PR TITLE
feat(trainee): OQM-0028 implement weekly tabs for session navigation on TraineePage

### DIFF
--- a/user_manuals/trainee-manual.en.md
+++ b/user_manuals/trainee-manual.en.md
@@ -26,13 +26,15 @@ Expected result:
 1. Open the app main view.
 2. Select Trainees.
 3. Wait until sessions are loaded.
-4. Choose a session card and select Register.
-5. If you are not logged in yet, fill your first name and last name in the form.
-6. If you are under 18, enable the underage checkbox and set your age.
-7. Select Ok.
-8. Review your registration details in the confirmation dialog.
-9. Select Ok to confirm registration.
-10. Wait for the result message.
+4. Review the week tabs above the session list.
+5. The current week opens by default. Select another week tab if you want to see sessions from a different week.
+6. Choose a session card and select Register.
+7. If you are not logged in yet, fill your first name and last name in the form.
+8. If you are under 18, enable the underage checkbox and set your age.
+9. Select Ok.
+10. Review your registration details in the confirmation dialog.
+11. Select Ok to confirm registration.
+12. Wait for the result message.
 
 Expected result:
 - You see Registration successfull.
@@ -78,6 +80,8 @@ Expected result:
   - Refresh data and retry.
 
 ## Notes About Session Cards
+- Session cards are grouped by day inside the selected week tab.
+- The current calendar week is shown first when it exists in the loaded session data.
 - Session cards show session name and time.
 - Coach name is shown only for free/sparring sessions.
 - Camp instructor is shown for camp sessions.

--- a/user_manuals/trainee-manual.fi.md
+++ b/user_manuals/trainee-manual.fi.md
@@ -26,13 +26,15 @@ Odotettu tulos:
 1. Avaa sovelluksen etusivu.
 2. Valitse Harrastajat.
 3. Odota, että harjoituslista latautuu.
-4. Valitse harjoituskortilta Ilmoittaudu.
-5. Jos et ole kirjautunut, täytä etu- ja sukunimi.
-6. Jos olet alle 18-vuotias, valitse alaikäinen ja aseta ikä.
-7. Valitse Ok.
-8. Tarkista tiedot vahvistusikkunassa.
-9. Valitse Ok vahvistaaksesi ilmoittautumisen.
-10. Odota tulosviesti.
+4. Tarkista harjoituslistan yläpuolella näkyvät viikkovälilehdet.
+5. Nykyinen viikko avautuu oletuksena. Valitse toinen viikkovälilehti, jos haluat nähdä toisen viikon harjoitukset.
+6. Valitse harjoituskortilta Ilmoittaudu.
+7. Jos et ole kirjautunut, täytä etu- ja sukunimi.
+8. Jos olet alle 18-vuotias, valitse alaikäinen ja aseta ikä.
+9. Valitse Ok.
+10. Tarkista tiedot vahvistusikkunassa.
+11. Valitse Ok vahvistaaksesi ilmoittautumisen.
+12. Odota tulosviesti.
 
 Odotettu tulos:
 - Näet viestin Ilmoittautuminen onnistui.
@@ -78,6 +80,8 @@ Odotettu tulos:
   - Päivitä tiedot ja yritä uudelleen.
 
 ## Huomiot harjoituskorteista
+- Harjoituskortit on ryhmitelty päivän mukaan valitun viikkovälilehden sisällä.
+- Nykyinen kalenteriviikko näytetään ensin, jos se löytyy ladatuista harjoituksista.
 - Kortti näyttää harjoituksen nimen ja ajan.
 - Valmentajan nimi näkyy vain vapaa/sparraus-harjoituksissa.
 - Leirin ohjaaja näkyy leiriharjoituksissa.

--- a/user_stories/trainee/features/OQM-0028-show-traineepage-training-cards-in-tabs/OQM-0028-show-traineepage-training-cards-in-tabs.md
+++ b/user_stories/trainee/features/OQM-0028-show-traineepage-training-cards-in-tabs/OQM-0028-show-traineepage-training-cards-in-tabs.md
@@ -1,0 +1,61 @@
+# Title
+OQM-0028: Show TraineePage session cards in weekly tabs (current week by default)
+
+## Summary
+Trainees need faster navigation through the 21-day session window on the trainee registration page.
+Replace the current flat date-grouped rendering with weekly tabs so trainees can view one calendar week (Mon-Sun) at a time. The current calendar week must be selected by default.
+
+## Problem
+The trainee session list can be hard to scan when many days are visible at once. Trainees requested week-level navigation to reduce scrolling and make session selection easier.
+
+## Scope
+- Add MUI Tabs and Tab to the trainee registration page.
+- Group existing date groups into calendar week buckets (Mon-Sun).
+- Default the selected tab to the current calendar week if present; otherwise the first available week.
+- Keep existing trainee registration, PIN registration, PIN login, logout, and refresh flows unchanged.
+- Add localized week tab labels (EN/FI).
+- Update trainee user manuals (EN/FI) for the new weekly navigation behavior.
+- Add frontend tests for tab rendering, default selection, and tab switching behavior.
+
+## Out of scope
+- Backend or GAS route changes.
+- Coach page behavior changes.
+- Broad refactor of shared date utilities.
+- Session card redesign beyond what is required for the new tab container.
+
+## User flow
+1. Trainee opens the trainee registration page.
+2. Trainee sees week tabs above the session list.
+3. The current calendar week is selected by default.
+4. Trainee switches tabs to view another week.
+5. Inside each tab, sessions remain grouped by date and rendered as SessionCards.
+6. Trainee can still register, refresh, log in with PIN, register a PIN, and log out as before.
+
+## Acceptance criteria
+1. Trainee registration shows week tabs when sessions are available.
+2. Tabs represent calendar weeks from Monday to Sunday.
+3. The current calendar week is selected by default when available.
+4. If the current week is not present, the first available week is selected.
+5. Selecting a week tab only shows sessions from that week.
+6. Sessions within the selected week remain grouped by day.
+7. Existing trainee Register/Login/Register PIN/Logout/Refresh behavior remains unchanged.
+8. New week tab labels are localized in English and Finnish.
+9. Trainee manuals in English and Finnish describe weekly tab usage.
+10. Tests cover:
+	- multi-week tab rendering
+	- default current-week selection
+	- tab switch visibility behavior
+	- no-tabs behavior when there are no sessions
+
+## Concrete test cases
+1. Given sessions in two different weeks, when TraineePage loads, then two tabs are rendered.
+2. Given sessions in current week and next week, when TraineePage loads, then the current-week session is visible and the next-week session is hidden.
+3. Given two week tabs, when the user clicks the second tab, then the second-week session is visible and the current-week session is hidden.
+4. Given only one week in the data, when TraineePage loads, then one tab is rendered and sessions are shown normally.
+5. Given no sessions, when TraineePage loads, then the no-sessions state is shown and the tab container is not shown.
+
+## Definition of done
+- [] Feature implemented and tests green.
+- [] Localization updated in EN/FI locale files.
+- [] User manuals updated in EN/FI.
+- [] PR includes manual impact and test evidence.

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -54,6 +54,8 @@
   "traineeRegistration.validationFailedAge": "Validation failed. Age is missing for underage trainee.",
   "traineeRegistration.cancel": "Cancel",
   "traineeRegistration.registeredIconLabel": "Registered session",
+  "traineeRegistration.weekTabLabel": "Week {{start}} - {{end}}",
+  "traineeRegistration.weekTabsAriaLabel": "Trainee session weeks",
   "manualTraineeRegistration.title": "Fill your information",
   "manualTraineeRegistration.firstName": "First name:",
   "manualTraineeRegistration.firstNamePlaceholder": "Your first name",

--- a/web/src/locales/fi.json
+++ b/web/src/locales/fi.json
@@ -54,6 +54,8 @@
   "traineeRegistration.validationFailedAge": "Validointi ep\u00e4onnistui. Alaik\u00e4isen ik\u00e4 puuttuu.",
   "traineeRegistration.cancel": "Peruuta",
   "traineeRegistration.registeredIconLabel": "Ilmoittautunut harjoitukseen",
+  "traineeRegistration.weekTabLabel": "Viikko {{start}} - {{end}}",
+  "traineeRegistration.weekTabsAriaLabel": "Harrastajan harjoitusviikot",
   "manualTraineeRegistration.title": "T\u00e4yt\u00e4 tietosi",
   "manualTraineeRegistration.firstName": "Etunimi:",
   "manualTraineeRegistration.firstNamePlaceholder": "Oma etunimesi",

--- a/web/src/pages/Trainee/TraineePage.tsx
+++ b/web/src/pages/Trainee/TraineePage.tsx
@@ -24,6 +24,8 @@ import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Container from '@mui/material/Container';
 import Stack from '@mui/material/Stack';
+import Tab from '@mui/material/Tab';
+import Tabs from '@mui/material/Tabs';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
 import Box from '@mui/material/Box';
@@ -55,6 +57,44 @@ function formatDateLabel(dateStr: string, locale: string): string {
   return `${weekday} ${String(day).padStart(2, '0')}.${String(month).padStart(2, '0')}.${year}`;
 }
 
+function toYmd(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function parseYmd(dateStr: string): Date {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  return new Date(year, month - 1, day);
+}
+
+function getWeekStartYmd(dateStr: string): string {
+  const date = parseYmd(dateStr);
+  const day = date.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  date.setDate(date.getDate() + diff);
+  return toYmd(date);
+}
+
+function addDaysToYmd(dateStr: string, daysToAdd: number): string {
+  const date = parseYmd(dateStr);
+  date.setDate(date.getDate() + daysToAdd);
+  return toYmd(date);
+}
+
+function formatWeekTabDate(dateStr: string): string {
+  const [, month, day] = dateStr.split('-');
+  return `${day}.${month}`;
+}
+
+interface WeekGroup {
+  weekKey: string;
+  weekStart: string;
+  weekEnd: string;
+  dates: Array<[string, TraineeSessionItem[]]>;
+}
+
 /** Trainee registration page displaying available sessions in a 21-day window. */
 export function TraineePage({ onBack }: TraineePageProps) {
   const { t, i18n } = useTranslation();
@@ -68,6 +108,7 @@ export function TraineePage({ onBack }: TraineePageProps) {
   const [pendingTraineeData, setPendingTraineeData] = useState<PendingTraineeData | undefined>(undefined);
   const [registerPinDialogOpen, setRegisterPinDialogOpen] = useState(false);
   const [loginDialogOpen, setLoginDialogOpen] = useState(false);
+  const [activeWeekTab, setActiveWeekTab] = useState('');
   /** True after a successful PIN registration; resets to false on logout. */
   const [traineePinRegistered, setTraineePinRegistered] = useState(false);
   /** Captures the submitted RegisterPinData so onSuccess can build PendingTraineeData. */
@@ -99,6 +140,42 @@ export function TraineePage({ onBack }: TraineePageProps) {
     }
     return grouped;
   }, [sessions]);
+
+  const sessionsByWeek = useMemo(() => {
+    const weekMap = new Map<string, WeekGroup>();
+    const dateEntries = Array.from(sessionsByDate.entries()).sort(([a], [b]) => a.localeCompare(b));
+
+    for (const [date, dateSessions] of dateEntries) {
+      const weekKey = getWeekStartYmd(date);
+      if (!weekMap.has(weekKey)) {
+        weekMap.set(weekKey, {
+          weekKey,
+          weekStart: weekKey,
+          weekEnd: addDaysToYmd(weekKey, 6),
+          dates: [],
+        });
+      }
+      weekMap.get(weekKey)!.dates.push([date, dateSessions]);
+    }
+
+    return weekMap;
+  }, [sessionsByDate]);
+
+  const weekTabs = useMemo(() => Array.from(sessionsByWeek.values()), [sessionsByWeek]);
+
+  useEffect(() => {
+    if (weekTabs.length === 0) {
+      if (activeWeekTab !== '') setActiveWeekTab('');
+      return;
+    }
+
+    const activeExists = weekTabs.some(week => week.weekKey === activeWeekTab);
+    if (activeExists) return;
+
+    const currentWeekKey = getWeekStartYmd(toYmd(new Date()));
+    const defaultWeek = weekTabs.find(week => week.weekKey === currentWeekKey) ?? weekTabs[0];
+    setActiveWeekTab(defaultWeek.weekKey);
+  }, [activeWeekTab, weekTabs]);
 
   function handleOpenRegister(session: TraineeSessionItem) {
     setSelectedSession(session);
@@ -305,24 +382,55 @@ export function TraineePage({ onBack }: TraineePageProps) {
         </Card>
       )}
 
-      {Array.from(sessionsByDate.entries()).map(([date, dateSessions]) => (
-        <Card key={date} sx={{ mb: 3, borderRadius: 3 }}>
-          <CardContent>
-            <Typography variant="subtitle1" fontWeight="bold" sx={{ mb: 1 }}>
-              {formatDateLabel(date, i18n.language)}
-            </Typography>
-            <Box sx={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center', gap: 2 }}>
-              {dateSessions.map(session => (
-                <TraineeSessionCard
-                  key={session.id}
-                  session={session}
-                  onRegister={handleOpenRegister}
+      {!loading && !error && weekTabs.length > 0 && (
+        <Card sx={{ mb: 2, borderRadius: 3 }}>
+          <CardContent sx={{ pb: 1 }}>
+            <Tabs
+              value={activeWeekTab || false}
+              onChange={(_event, value: string) => setActiveWeekTab(value)}
+              variant={weekTabs.length <= 3 ? 'standard' : 'scrollable'}
+              centered={weekTabs.length <= 3}
+              scrollButtons={weekTabs.length <= 3 ? false : 'auto'}
+              allowScrollButtonsMobile
+              aria-label={t('traineeRegistration.weekTabsAriaLabel')}
+            >
+              {weekTabs.map(week => (
+                <Tab
+                  key={week.weekKey}
+                  value={week.weekKey}
+                  label={t('traineeRegistration.weekTabLabel', {
+                    start: formatWeekTabDate(week.weekStart),
+                    end: formatWeekTabDate(week.weekEnd),
+                  })}
                 />
               ))}
-            </Box>
+            </Tabs>
           </CardContent>
         </Card>
-      ))}
+      )}
+
+      {weekTabs
+        .filter(week => week.weekKey === activeWeekTab)
+        .map(week =>
+          week.dates.map(([date, dateSessions]) => (
+            <Card key={date} sx={{ mb: 3, borderRadius: 3 }}>
+              <CardContent>
+                <Typography variant="subtitle1" fontWeight="bold" sx={{ mb: 1 }}>
+                  {formatDateLabel(date, i18n.language)}
+                </Typography>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center', gap: 2 }}>
+                  {dateSessions.map(session => (
+                    <TraineeSessionCard
+                      key={session.id}
+                      session={session}
+                      onRegister={handleOpenRegister}
+                    />
+                  ))}
+                </Box>
+              </CardContent>
+            </Card>
+          ))
+        )}
 
       <ManualTraineeRegistrationDialog
         open={manualDialogOpen}

--- a/web/src/pages/Trainee/__tests__/TraineePage.test.tsx
+++ b/web/src/pages/Trainee/__tests__/TraineePage.test.tsx
@@ -56,6 +56,51 @@ const mockSession: TraineeSessionItem = {
   is_free_sparring: false,
 };
 
+function toYmd(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function getMonday(date: Date): Date {
+  const copy = new Date(date);
+  const day = copy.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  copy.setDate(copy.getDate() + diff);
+  copy.setHours(0, 0, 0, 0);
+  return copy;
+}
+
+function addDays(date: Date, days: number): Date {
+  const copy = new Date(date);
+  copy.setDate(copy.getDate() + days);
+  return copy;
+}
+
+function buildMultiWeekSessions(): [TraineeSessionItem, TraineeSessionItem] {
+  const monday = getMonday(new Date());
+  const currentWeekDate = toYmd(addDays(monday, 2));
+  const nextWeekDate = toYmd(addDays(monday, 8));
+
+  return [
+    {
+      ...mockSession,
+      id: 'trainee-current-week',
+      session_type: 'Current Week Session',
+      session_type_alias: 'Current Week Session',
+      date: currentWeekDate,
+    },
+    {
+      ...mockSession,
+      id: 'trainee-next-week',
+      session_type: 'Next Week Session',
+      session_type_alias: 'Next Week Session',
+      date: nextWeekDate,
+    },
+  ];
+}
+
 describe('TraineePage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -99,6 +144,61 @@ describe('TraineePage', () => {
 
     expect(await screen.findByText('Basic')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Register' })).toBeInTheDocument();
+  });
+
+  it('renders week tabs when sessions span multiple calendar weeks', async () => {
+    const [currentWeekSession, nextWeekSession] = buildMultiWeekSessions();
+    mockGetTraineeSessions.mockResolvedValue([currentWeekSession, nextWeekSession]);
+
+    render(<TraineePage onBack={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('tab')).toHaveLength(2);
+    });
+  });
+
+  it('selects current week tab by default', async () => {
+    const [currentWeekSession, nextWeekSession] = buildMultiWeekSessions();
+    mockGetTraineeSessions.mockResolvedValue([currentWeekSession, nextWeekSession]);
+
+    render(<TraineePage onBack={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Current Week Session')).toBeInTheDocument();
+      expect(screen.queryByText('Next Week Session')).not.toBeInTheDocument();
+    });
+  });
+
+  it('switches visible sessions when another week tab is selected', async () => {
+    const [currentWeekSession, nextWeekSession] = buildMultiWeekSessions();
+    const user = userEvent.setup();
+    mockGetTraineeSessions.mockResolvedValue([currentWeekSession, nextWeekSession]);
+
+    render(<TraineePage onBack={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Current Week Session')).toBeInTheDocument();
+      expect(screen.queryByText('Next Week Session')).not.toBeInTheDocument();
+    });
+
+    const tabs = screen.getAllByRole('tab');
+    await user.click(tabs[1]);
+
+    await waitFor(() => {
+      expect(screen.getByText('Next Week Session')).toBeInTheDocument();
+      expect(screen.queryByText('Current Week Session')).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not render week tabs when no sessions are available', async () => {
+    mockGetTraineeSessions.mockResolvedValue([]);
+
+    render(<TraineePage onBack={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No sessions found')).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('tablist')).not.toBeInTheDocument();
   });
 
   it('opens manual dialog on Register and confirm dialog after pressing Ok', async () => {


### PR DESCRIPTION
# Title
feat: add weekly tabs to trainee session cards

## Summary
- Linked issue: #54 
- This PR adds weekly tab navigation to the trainee registration page so trainees can view one calendar week of sessions at a time instead of scanning the full 21-day list at once.

The trainee page now groups sessions into calendar weeks from Monday to Sunday and renders them in tabs. The current calendar week is selected by default when available. If the current week is not in the loaded data, the first available week is selected.

## Problem
The trainee session list became harder to scan when several days were shown at once. Trainees requested week-level navigation so they can focus on one week at a time and switch between weeks quickly.

## Scope
- Add MUI Tabs and Tab to the trainee registration page
- Group existing date groups into calendar week buckets from Monday to Sunday
- Default the selected tab to the current calendar week when present, otherwise the first available week
- Keep existing trainee registration, PIN registration, PIN login, logout, and refresh flows unchanged
- Add localized week tab labels in English and Finnish
- Update trainee manuals in English and Finnish
- Add frontend tests for tab rendering, default selection, and tab switching behavior

## Out of Scope
- Backend or GAS route changes
- Coach page behavior changes
- Broad refactor of shared date utilities
- Session card redesign beyond what is required for the new tab container

## Checklist
- [x] Tests added/updated and passing
- [x] No secrets committed
- [x] API contract adhered to
- [x] Updated docs/skills if schema or flows changed
